### PR TITLE
Add remote file support to `includes` shortcode 

### DIFF
--- a/docs/layouts/shortcodes/include.html
+++ b/docs/layouts/shortcodes/include.html
@@ -1,0 +1,29 @@
+{{ $file := .Get "file" }}
+{{ $url := .Get "url" }}
+{{ $type := .Get "type" }}
+{{ $language := .Get "language" }}
+{{ $options := .Get "options" }}
+
+<div class="gdoc-include">
+  {{- if $url -}}
+    {{- $resource := resources.GetRemote $url -}}
+    {{- $content := $resource.Content -}}
+    {{- if $language -}}
+      {{- highlight $content $language (default "linenos=table" $options) -}}
+    {{- else if eq $type "html" -}}
+      {{- $content | safeHTML -}}
+    {{- else -}}
+      {{- $content -}}
+    {{- end -}}
+  {{- else -}}
+    {{- if $language -}}
+      {{- highlight ($file | readFile) $language (default "linenos=table" $options) -}}
+    {{- else if eq $type "html" -}}
+      {{- $file | readFile | safeHTML -}}
+    {{- else if eq $type "page" -}}
+      {{- with .Site.GetPage $file }}{{ .Content }}{{ end -}}
+    {{- else -}}
+      {{- $file | readFile | $.Page.RenderString -}}
+    {{- end -}}
+  {{- end -}}
+</div>


### PR DESCRIPTION
This pull request introduces a new shortcode template in the `docs/layouts/shortcodes/include.html` file to handle the inclusion of external resources and files with various options for rendering content.

Key changes:

* Added variables to capture parameters for URL
* Implemented logic to fetch and render content based on the provided URL or file, with support for syntax highlighting, HTML rendering, and page content inclusion.

## Testing evidence
![Screenshot 2024-11-27 100429](https://github.com/user-attachments/assets/b3d65aee-0aae-4f03-a379-945944133a8f)

![Screenshot 2024-11-27 100409](https://github.com/user-attachments/assets/76f44ffb-6d95-48f4-a88f-bf85a8966b88)

![Screenshot 2024-11-27 100416](https://github.com/user-attachments/assets/153568b1-20ec-487e-86b9-069304522065)

