### PR TITLE
fix: correct path for archetype definition JSON in management groups documentation

### DIFF
--- a/docs/content/accelerator/startermodules/terraform-platform-landing-zone/options/management-groups.md
+++ b/docs/content/accelerator/startermodules/terraform-platform-landing-zone/options/management-groups.md
@@ -28,14 +28,14 @@ Follow these steps to customise the management group names and IDs:
 ```pwsh
 $filePath = "c:\accelerator\config\lib\archetype_definitions\alz.alz_architecture_definition.json"
 New-Item -ItemType "file" $filePath -Force
-(Invoke-WebRequest "https://raw.githubusercontent.com/Azure/Azure-Landing-Zones-Library/refs/heads/main/platform/alz/archetype_definitions/alz.alz_architecture_definition.json").Content | Out-File $filePath -Force
+(Invoke-WebRequest "https://raw.githubusercontent.com/Azure/Azure-Landing-Zones-Library/refs/heads/main/platform/alz/architecture_definitions/alz.alz_architecture_definition.json").Content | Out-File $filePath -Force
 ```
     {{< /tab >}}
     {{< tab "Linux / macOS" >}}
 ```pwsh
 $filePath = "/accelerator/config/lib/archetype_definitions/alz.alz_architecture_definition.json"
 New-Item -ItemType "file" $filePath -Force
-(Invoke-WebRequest "https://raw.githubusercontent.com/Azure/Azure-Landing-Zones-Library/refs/heads/main/platform/alz/archetype_definitions/alz.alz_architecture_definition.json").Content | Out-File $filePath -Force
+(Invoke-WebRequest "https://raw.githubusercontent.com/Azure/Azure-Landing-Zones-Library/refs/heads/main/platform/alz/architecture_definitions/alz.alz_architecture_definition.json").Content | Out-File $filePath -Force
 ```
     {{< /tab >}}
     {{< /tabs >}}


### PR DESCRIPTION
This pull request includes a small but important change to the `docs/content/accelerator/startermodules/terraform-platform-landing-zone/options/management-groups.md` file. The change updates the URL used in the PowerShell commands to download the `alz.alz_architecture_definition.json` file.

* Updated URL in PowerShell commands to correct the path for downloading `alz.alz_architecture_definition.json`