### PR TITLE
Fix tfvars Link

### DIFF
--- a/docs/content/accelerator/startermodules/terraform-platform-landing-zone/scenarios/multi-region-hub-and-spoke-vnet-with-nva.md
+++ b/docs/content/accelerator/startermodules/terraform-platform-landing-zone/scenarios/multi-region-hub-and-spoke-vnet-with-nva.md
@@ -5,7 +5,7 @@ weight: 3
 
 A full platform landing zone deployment with hub and spoke Virtual Network connectivity in multiple regions, ready for a third party Network Virtual Appliance (NVA).
 
-* Example platform landing zone configuration file: [full-multi-region-nva/virtual-wan.tfvars](https://raw.githubusercontent.com/Azure/alz-terraform-accelerator/refs/heads/main/templates/platform_landing_zone/examples/full-multi-region-nva/virtual-wan.tfvars)
+* Example platform landing zone configuration file: [full-multi-region-nva/hub-and-spoke-vnet.tfvars](https://raw.githubusercontent.com/Azure/alz-terraform-accelerator/refs/heads/main/templates/platform_landing_zone/examples/full-multi-region-nva/hub-and-spoke-vnet.tfvars)
 
 ## Resources
 


### PR DESCRIPTION
Fix for the issue: #44 

This pull request includes a small change to the `docs/content/accelerator/startermodules/terraform-platform-landing-zone/scenarios/multi-region-hub-and-spoke-vnet-with-nva.md` file. The change updates the link to the example platform landing zone configuration file to point to the correct `hub-and-spoke-vnet.tfvars` file.

* Updated the link to the example platform landing zone configuration file to `hub-and-spoke-vnet.tfvars` in `docs/content/accelerator/startermodules/terraform-platform-landing-zone/scenarios/multi-region-hub-and-spoke-vnet-with-nva.md`.