### PR TITLE
Rename AADS to Entra Domain Services

### DIFF
--- a/docs/content/accelerator/userguide/1_prerequisites/platform-subscriptions.md
+++ b/docs/content/accelerator/userguide/1_prerequisites/platform-subscriptions.md
@@ -19,7 +19,7 @@ If a parent management group other than Tenant Root Group is chosen, then you mu
 We recommend setting up 3 subscriptions for Azure landing zones. These are management, identity and connectivity. See our [advanced scenarios]({{< relref "advancedscenarios" >}}) section for alternatives.
 
 - Management: This is used to deploy the bootstrap and management resources, such as log analytics and automation accounts.
-- Identity: This is used to deploy the identity resources, such as Azure AD and Azure AD Domain Services.
+- Identity: This is used to deploy the identity resources, such as Azure AD and Microsoft Entra Domain Services (formerly Azure AD DS) .
 - Connectivity: This is used to deploy the hub networking resources, such as virtual networks and firewalls.
 
 You can read more about the management, identity and connectivity subscriptions in the [Landing Zone docs](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/deploy-landing-zones-with-terraform).

--- a/docs/content/bootstrap/_index.md
+++ b/docs/content/bootstrap/_index.md
@@ -12,7 +12,7 @@ These are management, identity and connectivity.
 
 - **Management**: This is used to deploy the bootstrap and management resources, such as log analytics and automation accounts.
 - **Connectivity**: This is used to deploy the hub networking resources, such as virtual networks and firewalls.
-- **Identity**: (Optional) This is used to deploy the identity resources, such as Azure AD and Azure AD Domain Services. You will not need this if you do not have any AD-DS or [Entra Domain Services](https://azure.microsoft.com/products/microsoft-entra-ds) requirements.
+- **Identity**: (Optional) This is used to deploy the identity resources, such as Azure AD and Microsoft Entra Domain Services (formerly Azure AD DS) . You will not need this if you do not have any AD-DS or [Entra Domain Services](https://azure.microsoft.com/products/microsoft-entra-ds) requirements.
 
 You can read more about the management, identity and connectivity subscriptions in the [Landing Zone docs](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/deploy-landing-zones-with-terraform).
 


### PR DESCRIPTION
This pull request includes updates to the documentation to reflect the renaming of Azure AD Domain Services to Microsoft Entra Domain Services. The changes ensure that the documentation is consistent with the latest terminology.

Updates to documentation:

* [`docs/content/accelerator/userguide/1_prerequisites/platform-subscriptions.md`](diffhunk://#diff-41a2b1a3dd35a8482d351e24ed5445595bf9c9bd077e2a29d485d52a0c0ac120L22-R22): Updated the description of identity resources to include the new name "Microsoft Entra Domain Services (formerly Azure AD DS)".
* [`docs/content/bootstrap/_index.md`](diffhunk://#diff-581b16a79d2dea353c76b489923cb2a103e361a30d117c6ef5ad340d84bad6edL15-R15): Updated the description of identity resources to include the new name "Microsoft Entra Domain Services (formerly Azure AD DS)".