### PR TITLE
fix: casing

### DIFF
--- a/docs/content/terraform/howtos/modifyingPolicyAssignments.md
+++ b/docs/content/terraform/howtos/modifyingPolicyAssignments.md
@@ -37,7 +37,7 @@ module "alz" {
 
         # Modifying a policy parameter...
         parameters = {
-          effect = jsonencode({Value = "Audit"})
+          effect = jsonencode({value = "Audit"})
         }
 
         # How to use resource selectors


### PR DESCRIPTION
The `value` is case-sensitive.