### PR TITLE
Helps keep the output directory present when empty

### DIFF
--- a/docs/content/accelerator/userguide/2_start/bicep-azuredevops.md
+++ b/docs/content/accelerator/userguide/2_start/bicep-azuredevops.md
@@ -21,6 +21,7 @@ Follow these instructions to bootstrap Azure DevOps ready to deploy your platfor
     ┣ 📂config
     ┃ ┗ 📜inputs.yaml
     ┗ 📂output
+      ┗ 📜.gitkeep
     ```
 
 1. Open your `inputs.yaml` file in Visual Studio Code (or your preferred editor) and copy the content from [inputs-azure-devops.yaml](https://raw.githubusercontent.com/Azure/alz-bicep/refs/heads/main/accelerator/examples/bootstrap/inputs-azure-devop.yaml) into that file.

--- a/docs/content/accelerator/userguide/2_start/bicep-github.md
+++ b/docs/content/accelerator/userguide/2_start/bicep-github.md
@@ -21,6 +21,7 @@ Follow these instructions to bootstrap GitHub ready to deploy your platform land
     ┣ 📂config
     ┃ ┗ 📜inputs.yaml
     ┗ 📂output
+      ┗ 📜.gitkeep
     ```
 
 1. Open your `inputs.yaml` file in Visual Studio Code (or your preferred editor) and copy the content from [inputs-github.yaml](https://raw.githubusercontent.com/Azure/alz-bicep/refs/heads/main/accelerator/examples/bootstrap/inputs-github.yaml) into that file.

--- a/docs/content/accelerator/userguide/2_start/bicep-local.md
+++ b/docs/content/accelerator/userguide/2_start/bicep-local.md
@@ -21,6 +21,7 @@ Follow these instructions to bootstrap a local file system folder ready to deplo
     ┣ 📂config
     ┃ ┗ 📜inputs.yaml
     ┗ 📂output
+      ┗ 📜.gitkeep
     ```
 
 1. Open your `inputs.yaml` file in Visual Studio Code (or your preferred editor) and copy the content from [inputs-local.yaml](https://raw.githubusercontent.com/Azure/alz-bicep/refs/heads/main/accelerator/examples/bootstrap/inputs-local.yaml) into that file.

--- a/docs/content/accelerator/userguide/2_start/terraform-azuredevops.md
+++ b/docs/content/accelerator/userguide/2_start/terraform-azuredevops.md
@@ -27,6 +27,7 @@ If you are using the FSI or SLZ starter modules, you do not currently require th
     ┃ ┃ 📜inputs.yaml
     ┃ ┗ 📜platform-landing-zone.tfvars
     ┗ 📂output
+      ┗ 📜.gitkeep
     ```
 
 1. Open your `inputs.yaml` file in Visual Studio Code (or your preferred editor) and copy the content from the relevant input file for your chosen starter module:

--- a/docs/content/accelerator/userguide/2_start/terraform-github.md
+++ b/docs/content/accelerator/userguide/2_start/terraform-github.md
@@ -27,6 +27,7 @@ If you are using the FSI or SLZ starter modules, you do not currently require th
     ┃ ┃ 📜inputs.yaml
     ┃ ┗ 📜platform-landing-zone.tfvars
     ┗ 📂output
+      ┗ 📜.gitkeep
     ```
 
 1. Open your `inputs.yaml` file in Visual Studio Code (or your preferred editor) and copy the content from the relevant input file for your chosen starter module:

--- a/docs/content/accelerator/userguide/2_start/terraform-local.md
+++ b/docs/content/accelerator/userguide/2_start/terraform-local.md
@@ -27,6 +27,7 @@ If you are using the FSI or SLZ starter modules, you do not currently require th
     ┃ ┃ 📜inputs.yaml
     ┃ ┗ 📜platform-landing-zone.tfvars
     ┗ 📂output
+      ┗ 📜.gitkeep
     ```
 
 1. Open your `inputs.yaml` file in Visual Studio Code (or your preferred editor) and copy the content from the relevant input file for your chosen starter module:


### PR DESCRIPTION
Maybe this was just me, but I fell into a hole when the `output` directory didn't tag along into the repo. This makes sure it's present.