### PR TITLE
Fix: Custom Policy Asset Resource ID

### DIFF
--- a/docs/content/terraform/howtos/modifyingPolicyAssets.md
+++ b/docs/content/terraform/howtos/modifyingPolicyAssets.md
@@ -46,7 +46,7 @@ Then you create a `<myassignment>.alz_policy_assignment.json` (or YAML) file in 
 {{< hint type=note >}}
 The resource id of the eventually deployed asset will not be known at the time of the file creation.
 Luckily, alzlib and the ALZ provider will index assets by their name only.
-When creating references between assets, you must specify a sane resource id, however the only segment that is used is the final one: e.g. in the example reference `/providers/Microsoft.Management/managementGroups/placeholder/Microsoft.Authorization/policyDefinitions/mydefinition` - the `mydefinition` segment is used to lookup the asset.
+When creating references between assets, you must specify a sane resource id, however the only segment that is used is the final one: e.g. in the example reference `/providers/Microsoft.Management/managementGroups/placeholder/providers/Microsoft.Authorization/policyDefinitions/mydefinition` - the `mydefinition` segment is used to lookup the asset.
 {{< /hint >}}
 
 ## Step two - Create an override archetype


### PR DESCRIPTION
The example resource ID within the documentation for [Assigning Custom policy Assets](https://azure.github.io/Azure-Landing-Zones/terraform/howtos/modifyingPolicyAssets/#assigning-a-custom-policy-definition-or-policy-set-definition) is missing an additional `/providers/` segment after `/placeholder`.

The Azure Landing Zone Library existing custom assets, for example the [Enforce-ALZ-Decom](https://github.com/Azure/Azure-Landing-Zones-Library/blob/main/platform/alz/policy_assignments/Enforce-ALZ-Decomm.alz_policy_assignment.json#L13), has the following resource ID structure:

- `/providers/Microsoft.Management/managementGroups/placeholder/providers/Microsoft.Authorization/policySetDefinitions/Enforce-ALZ-Decomm`

Documentation suggests the structure:  

- ` /providers/Microsoft.Management/managementGroups/placeholder/Microsoft.Authorization/policyDefinitions/mydefinition`

If you follow the documentation, it cannot replace the resource ID scope for the specific management group and ultimately fails:

<img width="1267" height="574" alt="image" src="https://github.com/user-attachments/assets/13de0dc5-6bff-45b8-ba77-1aadd228eddd" />
