### PR TITLE
fix: Fix typo in feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: File a feature request for Azure landing zone tools or guidance
-title: "[Feautre Request]: "
+title: "[Feature Request]: "
 labels: ["Needs: Triage :mag:"]
 projects: []
 body:
@@ -42,6 +42,7 @@ body:
       render: Text
     validations:
       required: false
+
 
 
   


### PR DESCRIPTION
This pull request makes a minor correction to the feature request issue template by fixing a typo in the default title.

* Corrected the spelling of "Feature Request" in the `title` field of `.github/ISSUE_TEMPLATE/feature-request.yml`