### PR TITLE
fix: Update Accelerator Architecture Definition File Reference

### DIFF
--- a/docs/content/accelerator/startermodules/terraform-platform-landing-zone/options/amba.md
+++ b/docs/content/accelerator/startermodules/terraform-platform-landing-zone/options/amba.md
@@ -60,9 +60,9 @@ The bootstrap process generates a YAML file by default, but JSON format is also 
 
 {{< highlight terraform "linenos=table" >}}
 locals {
-  root_management_group_name = yamldecode(file("${path.root}/lib/architecture_definitions/alz.alz_architecture_definition.yaml")).management_groups[0].id
+  root_management_group_name = yamldecode(file("${path.root}/lib/architecture_definitions/alz_custom.alz_architecture_definition.yaml")).management_groups[0].id
 
-  # root_management_group_name = jsondecode(file("${path.root}/lib/architecture_definitions/alz.alz_architecture_definition.json")).management_groups[0].id
+  # root_management_group_name = jsondecode(file("${path.root}/lib/architecture_definitions/alz_custom.alz_architecture_definition.json")).management_groups[0].id
 }
 
 module "amba" {


### PR DESCRIPTION
Updated Architecture Definition File Name Reference to the one in the accelerator to remove confusion

Fixes [#558](https://github.com/Azure/Azure-Landing-Zones/issues/558) & [#557](https://github.com/Azure/Azure-Landing-Zones/issues/557)
