### PR TITLE
docs: fix DDoS protection policy assignment documentation

### DIFF
--- a/docs/content/bicep/howtos/modifyingPolicyAssignments.md
+++ b/docs/content/bicep/howtos/modifyingPolicyAssignments.md
@@ -30,18 +30,17 @@ param parPolicyAssignmentParameterOverrides = {
 
 ## Disabling a Policy Assignment
 
-Let's say you want to disable the `Enable-DDoS-VNET` policy assignment. You can either set its enforcement mode to DoNotEnforce or exclude it entirely from deployment.
+You can either set a policy assignment's enforcement mode to DoNotEnforce or exclude it entirely from deployment.
 
-To change the Enforcement mode of a policy assignment to DoNoteEnforce, but still assign the policy, add it to the `managementGroupDoNotEnforcePolicyAssignments` array in the corresponding management group's `.bicepparam` file:
+To change the Enforcement mode of a policy assignment to DoNotEnforce, but still assign the policy, add it to the `managementGroupDoNotEnforcePolicyAssignments` array in the corresponding management group's `.bicepparam` file:
 
-**landingzones/main.bicepparam:**
-**platform/platform-connectivity/main.bicepparam:**
+**Example using `landingzones/main.bicepparam`:**
 
 ```bicep-params
-param platformConfig = {
+param landingZonesConfig = {
   // ... other config
   managementGroupDoNotEnforcePolicyAssignments: [
-    'Enable-DDoS-VNET'  // This policy will be set to DoNotEnforce mode
+    'Deny-Subnet-Without-Nsg'  // This policy will be set to DoNotEnforce mode
   ]
 }
 ```
@@ -49,10 +48,10 @@ param platformConfig = {
 Alternatively, you can exclude a policy assignment entirely from the deployment using `managementGroupExcludedPolicyAssignments`:
 
 ```bicep-params
-param platformConfig = {
+param landingZonesConfig = {
   // ... other config
   managementGroupExcludedPolicyAssignments: [
-    'Enable-DDoS-VNET'  // This policy will not be deployed at all
+    'Deny-Subnet-Without-Nsg'  // This policy will not be deployed at all
   ]
 }
 ```
@@ -163,12 +162,55 @@ param parPolicyAssignmentParameterOverrides = {
 
 ### DDoS Protection {#ddos-protection}
 
-If you don't have a DDoS protection plan, disable the `Enable-DDoS-VNET` policy assignment at the `platform` management group:
+The `Enable-DDoS-VNET` policy assignment is deployed at two management groups:
 
-**platform/main.bicepparam:**
+- **Connectivity** management group — via `lib/alz/platform/connectivity/Enable-DDoS-VNET.alz_policy_assignment.json`
+- **Landing Zones** management group — via `lib/alz/landingzones/Enable-DDoS-VNET.alz_policy_assignment.json`
+
+#### Keeping the policy enabled
+
+If you plan to keep the policy enabled, make sure you provide the DDoS protection plan resource ID via the `Enable-DDoS-VNET` override in both management group parameter files:
+
+**platform-connectivity/main.bicepparam:**
 
 ```bicep-params
-param platformConfig = {
+param parPolicyAssignmentParameterOverrides = {
+  'Enable-DDoS-VNET': {
+    parameters: {
+      ddosPlan: {
+        value: '/subscriptions/<subscription-id>/resourceGroups/<rg-name>/providers/Microsoft.Network/ddosProtectionPlans/<plan-name>'
+      }
+    }
+  }
+}
+```
+
+**landingzones/main.bicepparam:**
+
+```bicep-params
+param parPolicyAssignmentParameterOverrides = {
+  'Enable-DDoS-VNET': {
+    parameters: {
+      ddosPlan: {
+        value: '/subscriptions/<subscription-id>/resourceGroups/<rg-name>/providers/Microsoft.Network/ddosProtectionPlans/<plan-name>'
+      }
+    }
+  }
+}
+```
+
+#### Disabling the policy
+
+{{< hint type=important >}}
+The `Enable-DDoS-VNET` policy uses a `Modify` effect with `Default` enforcement mode. This means the policy actively intercepts VNet creation and update requests to inject the DDoS protection plan reference. If the policy is deployed with placeholder parameter values and no DDoS protection plan exists, VNet deployments will fail with `LinkedAuthorizationFailed` errors. Make sure the governance stacks are updated and deployed before running the networking stack.
+{{< /hint >}}
+
+If you don't have a DDoS protection plan, exclude the `Enable-DDoS-VNET` policy assignment from both management groups:
+
+**platform-connectivity/main.bicepparam:**
+
+```bicep-params
+param platformConnectivityConfig = {
   // ... other config
   managementGroupExcludedPolicyAssignments: [
     'Enable-DDoS-VNET'
@@ -176,29 +218,33 @@ param platformConfig = {
 }
 ```
 
-Or set it to DoNotEnforce mode:
+**landingzones/main.bicepparam:**
 
 ```bicep-params
-param platformConfig = {
+param landingZonesConfig = {
   // ... other config
-  managementGroupDoNotEnforcePolicyAssignments: [
+  managementGroupExcludedPolicyAssignments: [
     'Enable-DDoS-VNET'
   ]
 }
 ```
 
-If you plan to keep the policy enabled, make sure you provide the DDoS protection plan resource ID via the `Enable-DDoS-VNET` override:
+You must also update the cross-management group RBAC parameter files to exclude the policy assignment. These modules reference the policy assignment as an `existing` resource to retrieve its managed identity, and will fail if the assignment does not exist.
+
+**platform/main-rbac.bicepparam:**
 
 ```bicep-params
-param parPolicyAssignmentParameterOverrides = {
-  'Enable-DDoS-VNET': {
-    parameters: {
-      ddosProtectionPlanId: {
-        value: '/subscriptions/<subscription-id>/resourceGroups/<rg-name>/providers/Microsoft.Network/ddosProtectionPlans/<plan-name>'
-      }
-    }
-  }
-}
+param parManagementGroupExcludedPolicyAssignments = [
+  'Enable-DDoS-VNET'
+]
+```
+
+**landingzones/main-rbac.bicepparam:**
+
+```bicep-params
+param parManagementGroupExcludedPolicyAssignments = [
+  'Enable-DDoS-VNET'
+]
 ```
 
 ### Private DNS Zones


### PR DESCRIPTION
## Summary

Fixes incorrect and misleading documentation in the **Modifying Policy Assignments** how-to guide for the `Enable-DDoS-VNET` policy assignment.

## What changed

### DDoS Protection section (rewritten)

- **Fixed incorrect management group references**: The docs previously stated the policy exists at the `platform` management group. It actually exists at **Connectivity** (`lib/alz/platform/connectivity/`) and **Landing Zones** (`lib/alz/landingzones/`).
- **Fixed incorrect parameter name**: Changed `ddosProtectionPlanId` to the correct `ddosPlan` parameter name.
- **Added Modify effect warning**: The policy uses a `Modify` effect with `Default` enforcement, which actively intercepts VNet creation requests. If placeholder values are present and no DDoS plan exists, deployments fail with `LinkedAuthorizationFailed`. This is now clearly documented.
- **Added RBAC sync instructions**: When excluding the policy, the cross-management group RBAC parameter files (`main-rbac.bicepparam`) must also be updated, otherwise the `existing` resource lookup for the policy assignment's managed identity will fail.
- **Added override instructions**: For users keeping the policy enabled, added examples showing how to provide the DDoS plan resource ID via `parPolicyAssignmentParameterOverrides` in both management group parameter files.
- **Restructured into clear paths**: Split into "Keeping the policy enabled" and "Disabling the policy" subsections.

### Generic "Disabling a Policy Assignment" section

- **Fixed typo**: `DoNoteEnforce` to `DoNotEnforce`.
- **Replaced misleading example**: The generic example used `Enable-DDoS-VNET` at the `platform` management group (which doesn't exist). Replaced with `Deny-Subnet-Without-Nsg` at `landingzones` as a more accurate example.

## Why

These documentation issues led to real deployment failures where customers following the guide would configure the wrong management groups and parameter names, resulting in `PolicyAssignmentNotFound` and `LinkedAuthorizationFailed` errors during deployment stack runs.
