### PR TITLE
chore: Update March 2026 section with ALZ Library changes & add feature to support expanding section by default

### DIFF
--- a/docs/content/whats-new/_index.md
+++ b/docs/content/whats-new/_index.md
@@ -14,6 +14,12 @@ Azure landing zone IaC accelerator release notes are [HERE]({{% ref "accelerator
 
 ### March 2026
 
+#### Policy
+
+- **IMPORTANT:** Updated ALZ Library to version: [`2026.01.3`](https://github.com/Azure/Azure-Landing-Zones-Library/releases/tag/platform%2Falz%2F2026.01.3) to handle the mapping of resource group location correctly in the assignment called `Deploy-SvcHealth-BuiltIn` of the built-in definition of [`[Preview]: Configure subscriptions to enable service health alert monitoring rule`](https://www.azadvertizer.net/azpolicyadvertizer/98903777-a9f6-47f5-90a9-acaf62ab01a8.html) which was previously being incorrectly set to `${default_location}` in the ALZ Terraform AVM-based deployment option. Please update your library version to the latest by following the guidance here: [Updating the module and library version](https://azure.github.io/Azure-Landing-Zones/terraform/howtos/update/#updating-the-policy-library)
+  - For clarity the ALZ Bicep AVM-based deployment does not require and update as this was replacing the token placeholder correctly 👍
+  - Sovereign landing zone (SLZ) Terraform deployments should also update to the latest library release of SLZ, which is [`2026.02.2`](https://github.com/Azure/Azure-Landing-Zones-Library/releases/tag/platform%2Fslz%2F2026.02.2)
+
 #### Tooling
 
 - Updated the ***Baseline alerts and monitoring*** integration section in the portal accelerator to deploy the latest release of AMBA (2026-03-06). To read more on the changes, see the [What's new](https://aka.ms/amba/alz/whatsnew) page in the AMBA documentation.

--- a/docs/content/whats-new/_index.md
+++ b/docs/content/whats-new/_index.md
@@ -10,7 +10,7 @@ Here's what's changed in Azure landing zone:
 Azure landing zone IaC accelerator release notes are [HERE]({{% ref "accelerator/accelerator-release-notes" %}})
 {{</hint >}}
 
-{{< expand "March 2026" ">" >}}
+{{< expand title="March 2026" icon=">" expandByDefault="true" >}}
 
 ### March 2026
 

--- a/docs/layouts/shortcodes/expand.html
+++ b/docs/layouts/shortcodes/expand.html
@@ -1,0 +1,14 @@
+{{ $id := substr (sha1 .Inner) 0 8 }}
+{{ $title := or (.Get "title") (.Get 0) "Expand" }}
+{{ $icon := or (.Get "icon") (.Get 1) "↕" }}
+{{ $expandByDefault := eq (.Get "expandByDefault") "true" }}
+<div class="gdoc-expand">
+  <label class="gdoc-expand__head flex justify-between" for="{{ $id }}-{{ .Ordinal }}">
+    <span>{{ $title }}</span>
+    <span>{{ $icon }}</span>
+  </label>
+  <input id="{{ $id }}-{{ .Ordinal }}" type="checkbox" class="gdoc-expand__control hidden"{{ if $expandByDefault }} checked{{ end }} />
+  <div class="gdoc-markdown--nested gdoc-expand__content">
+    {{ .Inner | $.Page.RenderString }}
+  </div>
+</div>


### PR DESCRIPTION
This pull request introduces an important update to the Azure landing zone documentation and enhances the expand/collapse shortcode used in the documentation site. The main changes include a critical policy update in the March 2026 release notes and a more flexible, accessible expand/collapse component for documentation content.

**Documentation Updates:**

* Added a critical policy update for March 2026, highlighting the need to update the ALZ Library to version `2026.01.3` for correct resource group location mapping in the `Deploy-SvcHealth-BuiltIn` assignment. Also clarified that Bicep AVM-based deployments are unaffected and provided guidance for Sovereign landing zone (SLZ) updates.

**Shortcode Improvements:**

* Introduced a new `expand.html` shortcode that supports customizable titles, icons, and an option to expand by default. This improves the user experience and accessibility of expandable content in documentation.