### PR TITLE
docs: add SMB scenarios, mark identity/security subs as optional, add DDoS warnings

### DIFF
--- a/docs/content/accelerator/0_planning.md
+++ b/docs/content/accelerator/0_planning.md
@@ -132,7 +132,11 @@ Fill out the `Parent management group id` value with the management group you ha
 {{< /hint >}}
 
 {{< hint type=warning >}}
-**SMB (Small-Medium Business) minimum: 2 subscriptions.** If you are a small business that has not yet scaled and you are using one of the [SMB scenarios]({{< relref "starter-terraform/scenarios#smb-small-medium-business-scenarios" >}}), you can start with just **Management** and **Connectivity** subscriptions. However, this is only a starting point — as your organization grows, you **will** need to add dedicated Identity and Security subscriptions. Plan for this from the outset.
+**SMB (Small-Medium Business) minimum: 2 subscriptions.** These scenarios are designed for small-medium businesses **only** (e.g. less than 10 workloads or less than 100/200 FTEs) that want to start with an Azure landing zone (ALZ) aligned platform landing zone but perhaps are not yet ready for the full scale of ALZ and the associated cost. However, they want to start on the right path and not pin themselves in to an architecture they cannot expand upon later. 
+
+They are cost-optimized with reduced resource deployment, out of the box.
+
+Identity and security subscriptions are recommended but optional in these scenarios also and should be planned for from the start.
 {{< /hint >}}
 
 The 4 recommended platform subscriptions are:

--- a/docs/content/accelerator/0_planning.md
+++ b/docs/content/accelerator/0_planning.md
@@ -127,11 +127,26 @@ Fill out the `Parent management group id` value with the management group you ha
 
 ### Decision 7 - Choose the platform subscriptions
 
-We require 4 platform subscriptions: Management, Connectivity, Identity, and Security.
+{{< hint type=tip >}}
+**Recommended: 4 subscriptions.** We strongly recommend setting up all 4 platform subscriptions (Management, Connectivity, Identity, and Security) for a complete and well-architected landing zone.
+{{< /hint >}}
 
-You may wish to follow the steps in the [phase 1 prerequisites]({{< relref "1_prerequisites/platform-subscriptions">}}) to create the 4 platform subscriptions and add the subscription IDs to the checklist now.
+{{< hint type=warning >}}
+**SMB (Small-Medium Business) minimum: 2 subscriptions.** If you are a small business that has not yet scaled and you are using one of the [SMB scenarios]({{< relref "starter-terraform/scenarios#smb-small-medium-business-scenarios" >}}), you can start with just **Management** and **Connectivity** subscriptions. However, this is only a starting point — as your organization grows, you **will** need to add dedicated Identity and Security subscriptions. Plan for this from the outset.
+{{< /hint >}}
 
-Fill out the `Management subscription id`, `Connectivity subscription id`, `Identity subscription id`, and `Security subscription id` values with the subscription IDs you have chosen.
+The 4 recommended platform subscriptions are:
+
+- **Management** (required): Used to deploy the bootstrap and management resources, such as log analytics and automation accounts.
+- **Connectivity** (required): Used to deploy the hub networking resources, such as virtual networks and firewalls.
+- **Identity** (recommended): Used to deploy the identity resources, such as Azure AD and Microsoft Entra Domain Services. *Can be deferred for SMB scenarios, but will be required as you scale.*
+- **Security** (recommended): Used to deploy Sentinel and other security related resources. *Can be deferred for SMB scenarios, but will be required as you scale.*
+
+You may wish to follow the steps in the [phase 1 prerequisites]({{< relref "1_prerequisites/platform-subscriptions">}}) to create the platform subscriptions and add the subscription IDs to the checklist now.
+
+**For 4 subscriptions (recommended):** Fill out the `Management subscription id`, `Connectivity subscription id`, `Identity subscription id`, and `Security subscription id` values with the subscription IDs you have chosen.
+
+**For 2 subscriptions (SMB only):** Fill out the `Management subscription id` and `Connectivity subscription id` values. Leave `Identity subscription id` and `Security subscription id` blank. You will need to add these later as your organization scales.
 
 ### Decision 8 - Choose the bootstrap subscription
 

--- a/docs/content/accelerator/1_prerequisites/platform-subscriptions.md
+++ b/docs/content/accelerator/1_prerequisites/platform-subscriptions.md
@@ -26,7 +26,7 @@ The 4 recommended platform subscriptions are:
 You can read more about the management, identity, connectivity, and security subscriptions in the [Landing Zone docs](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/deploy-landing-zones-with-terraform).
 
 {{< hint type=warning >}}
-**SMB (Small-Medium Business) minimum: 2 subscriptions.** If you are a small business that has not yet scaled and you are using one of the [SMB scenarios]({{< relref "../../accelerator/starter-terraform/scenarios#smb-small-medium-business-scenarios" >}}), you can start with just the **Management** and **Connectivity** subscriptions. The Identity and Security subscription placements are commented out in the SMB configuration files and can be enabled later.
+**SMB (Small-Medium Business) minimum: 2 subscriptions.** If you are a small business that has not yet scaled and you are using, or planning to use, one of the [SMB scenarios]({{< relref "../../accelerator/starter-terraform/scenarios#smb-small-medium-business-scenarios" >}}), you can start with just the **Management** and **Connectivity** subscriptions. The Identity and Security subscription placements are commented out in the SMB configuration files and can be enabled later.
 
 **Important:** This is only a starting point. As your organization grows, you **will** need to add dedicated Identity and Security subscriptions. Plan for this from the outset.
 {{< /hint >}}

--- a/docs/content/accelerator/1_prerequisites/platform-subscriptions.md
+++ b/docs/content/accelerator/1_prerequisites/platform-subscriptions.md
@@ -13,7 +13,7 @@ You will need to choose the parent management group for your Platform landing zo
 ## 2 - Azure Subscriptions
 
 {{< hint type=tip >}}
-**Recommended: 4 subscriptions.** We strongly recommend setting up all 4 platform subscriptions for a complete and well-architected landing zone.
+**Recommended: 4 subscriptions.** We strongly recommend setting up all 4 platform subscriptions for a complete and well-architected landing zone. Migrating resources between subscriptions can be a complex and time-consuming process and not it is not supported for all resource types. See [here](https://learn.microsoft.com/azure/azure-resource-manager/management/move-resources-overview) for more details. 
 {{< /hint >}}
 
 The 4 recommended platform subscriptions are:

--- a/docs/content/accelerator/1_prerequisites/platform-subscriptions.md
+++ b/docs/content/accelerator/1_prerequisites/platform-subscriptions.md
@@ -12,21 +12,35 @@ You will need to choose the parent management group for your Platform landing zo
 
 ## 2 - Azure Subscriptions
 
-We recommend setting up 4 subscriptions for Platform landing zone. These are management, identity, connectivity, and security. See our [advanced scenarios]({{< relref "advancedscenarios" >}}) section for alternatives.
+{{< hint type=tip >}}
+**Recommended: 4 subscriptions.** We strongly recommend setting up all 4 platform subscriptions for a complete and well-architected landing zone.
+{{< /hint >}}
 
-- Management: This is used to deploy the bootstrap and management resources, such as log analytics and automation accounts.
-- Identity: This is used to deploy the identity resources, such as Azure AD and Microsoft Entra Domain Services.
-- Connectivity: This is used to deploy the hub networking resources, such as virtual networks and firewalls.
-- Security: This is used to deploy Sentinel and other security related resources.
+The 4 recommended platform subscriptions are:
+
+- **Management** (required): This is used to deploy the bootstrap and management resources, such as log analytics and automation accounts.
+- **Connectivity** (required): This is used to deploy the hub networking resources, such as virtual networks and firewalls.
+- **Identity** (recommended): This is used to deploy the identity resources, such as Azure AD and Microsoft Entra Domain Services.
+- **Security** (recommended): This is used to deploy Sentinel and other security related resources.
 
 You can read more about the management, identity, connectivity, and security subscriptions in the [Landing Zone docs](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/deploy-landing-zones-with-terraform).
+
+{{< hint type=warning >}}
+**SMB (Small-Medium Business) minimum: 2 subscriptions.** If you are a small business that has not yet scaled and you are using one of the [SMB scenarios]({{< relref "../../accelerator/starter-terraform/scenarios#smb-small-medium-business-scenarios" >}}), you can start with just the **Management** and **Connectivity** subscriptions. The Identity and Security subscription placements are commented out in the SMB configuration files and can be enabled later.
+
+**Important:** This is only a starting point. As your organization grows, you **will** need to add dedicated Identity and Security subscriptions. Plan for this from the outset.
+{{< /hint >}}
 
 To create the subscriptions you will need access to a billing agreement. The following links detail the permissions required for each type of agreement:
 
 - [Enterprise Agreement (EA)](https://learn.microsoft.com/azure/cost-management-billing/manage/create-enterprise-subscription)
 - [Microsoft Customer Agreement (MCA)](https://learn.microsoft.com/azure/cost-management-billing/manage/create-subscription)
 
-Once you have the access required, create the four subscriptions following your desired naming convention.
+Once you have the access required, create the subscriptions following your desired naming convention.
+
+**For the recommended 4-subscription model:** Create all four subscriptions (Management, Connectivity, Identity, Security).
+
+**For the SMB 2-subscription model:** Create the Management and Connectivity subscriptions. You will add Identity and Security subscriptions later as your organization scales.
 
 Take note of the subscription id of each subscription as we will need them later.
 
@@ -38,7 +52,7 @@ You need either an Azure User Account or Service Principal with the following pe
 
 - `Owner` on your chosen parent management group.
   - `Owner` is required because this account grants permissions to the identities that run the management group deployment. Those identities are granted only the permissions they need.
-- `Owner` on each of your 4 Platform landing zone subscriptions.
+- `Owner` on each of your platform landing zone subscriptions (4 for standard deployments, or 2 for SMB deployments).
 
 ### Bicep has one additional requirement:
 

--- a/docs/content/accelerator/accelerator-release-notes.md
+++ b/docs/content/accelerator/accelerator-release-notes.md
@@ -21,6 +21,35 @@ While we try very hard to avoid breaking changes, there are times when a feature
 
 ## Release Notes
 
+### [Terraform Starter Module - v15.5.0](https://github.com/Azure/alz-terraform-accelerator/releases/tag/v15.5.0), [Accelerator Bootstrap Modules - v7.2.0](https://github.com/Azure/accelerator-bootstrap-modules/releases/tag/v7.2.0), and [ALZ PowerShell Module - v7.1.0](https://github.com/Azure/ALZ-PowerShell-Module/releases/tag/v7.1.0)
+
+- Release date: 2026-04-01
+- Release link: [Terraform Starter Module - v15.5.0](https://github.com/Azure/alz-terraform-accelerator/releases/tag/v15.5.0), [Accelerator Bootstrap Modules - v7.2.0](https://github.com/Azure/accelerator-bootstrap-modules/releases/tag/v7.2.0), and [ALZ PowerShell Module - v7.1.0](https://github.com/Azure/ALZ-PowerShell-Module/releases/tag/v7.1.0)
+- Release diff: [Terraform Starter Module - v13.0.0...v15.5.0](https://github.com/Azure/alz-terraform-accelerator/compare/v13.0.0...v15.5.0), [Accelerator Bootstrap Modules - v7.0.0...v7.2.0](https://github.com/Azure/accelerator-bootstrap-modules/compare/v7.0.0...v7.2.0), and [ALZ PowerShell Module - v7.0.0...v7.1.0](https://github.com/Azure/ALZ-PowerShell-Module/compare/v7.0.0...v7.1.0)
+
+This release introduces new SMB (Small-Medium Business) scenarios and a 2 subscription model for the ALZ Terraform Accelerator.
+
+#### New SMB Scenarios
+
+Two new cost-optimized scenarios have been added for small-medium businesses:
+
+- **SMB Single-Region Hub and Spoke Virtual Network with Azure Firewall**: A cost-optimized deployment using hub and spoke Virtual Network connectivity with Azure Firewall (Basic SKU) in a single region.
+- **SMB Single-Region Virtual WAN with Azure Firewall**: A cost-optimized deployment using Virtual WAN network connectivity with Azure Firewall (Basic SKU) in a single region.
+
+These scenarios are designed for small-medium businesses that want to start with an ALZ aligned platform landing zone but are not yet ready for the full scale and associated cost. They are cost-optimized with reduced resource deployment out of the box and can be expanded upon later without redeployment.
+
+#### 2 Subscription Model
+
+Identity and Security platform subscriptions are now marked as optional. The SMB scenarios use a minimum of 2 subscriptions (Management and Connectivity), with Identity and Security subscription placements commented out in the configuration files. These can be enabled later as the organization scales.
+
+The 4 subscription model remains the recommended approach for a complete and well-architected landing zone.
+
+#### DDoS Protection Warnings
+
+The SMB scenarios disable the DDoS Network Protection Plan to reduce costs. Clear warnings have been added to the documentation advising users to consider and plan how to sufficiently protect their applications and workloads from DDoS attacks, such as using DDoS IP Protection per public IP.
+
+---
+
 ### [ALZ PowerShell Module - v7.0.0](https://github.com/Azure/ALZ-PowerShell-Module/releases/tag/v7.0.0) and [Accelerator Bootstrap Modules - v7.0.0](https://github.com/Azure/accelerator-bootstrap-modules/releases/tag/v7.0.0)
 
 - Release date: 2026-01-30

--- a/docs/content/accelerator/starter-terraform/options/ddos.md
+++ b/docs/content/accelerator/starter-terraform/options/ddos.md
@@ -7,7 +7,7 @@ weight: 3
 You can choose to not deploy a DDOS protection plan. In order to do that, they need to remove the DDOS protection plan configuration and disable the DINE (deploy if not exists) policy. You can either comment out or remove the configuration entirely.
 
 {{< hint type=danger >}}
-**Security Risk:** DDoS Protection Plan is a critical security control for public-facing services. Disabling it without an alternative leaves your workloads vulnerable to DDoS attacks. If you turn off the DDoS Protection Plan, you **MUST** implement [Azure DDoS IP Protection](https://learn.microsoft.com/azure/ddos-protection/ddos-protection-sku-comparison) on every public IP address in your environment to maintain your security posture. Failure to do so exposes your public-facing services to potential service disruption.
+**Security Risk:** A DDoS Network Protection Plan is a recommended security control for public-facing services. Disabling it without an alternative may leave your applications and workloads vulnerable to DDoS attacks. You should weigh up the pros and cons of before deciding to disable the DDoS Network Protection Plan and also consider how you will protect your applications and services without it. You may decide the DDoS IP Protection offering per-Public IP is a suitable option, as detailed [here](https://learn.microsoft.com/azure/ddos-protection/ddos-protection-sku-comparison), or an alternative solution. 
 {{< /hint >}}
 
 The steps to follow are:

--- a/docs/content/accelerator/starter-terraform/options/ddos.md
+++ b/docs/content/accelerator/starter-terraform/options/ddos.md
@@ -6,8 +6,8 @@ weight: 3
 
 You can choose to not deploy a DDOS protection plan. In order to do that, they need to remove the DDOS protection plan configuration and disable the DINE (deploy if not exists) policy. You can either comment out or remove the configuration entirely.
 
-{{< hint type=warning >}}
-DDOS Protection plan is a critical security protection for public facing services. Carefully consider this and be sure to put in place an alternative solution, such as per IP protection.
+{{< hint type=danger >}}
+**Security Risk:** DDoS Protection Plan is a critical security control for public-facing services. Disabling it without an alternative leaves your workloads vulnerable to DDoS attacks. If you turn off the DDoS Protection Plan, you **MUST** implement [Azure DDoS IP Protection](https://learn.microsoft.com/azure/ddos-protection/ddos-protection-sku-comparison) on every public IP address in your environment to maintain your security posture. Failure to do so exposes your public-facing services to potential service disruption.
 {{< /hint >}}
 
 The steps to follow are:

--- a/docs/content/accelerator/starter-terraform/scenarios/_index.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/_index.md
@@ -22,7 +22,9 @@ The available scenarios are:
 
 ### SMB (Small-Medium Business) Scenarios
 
-These scenarios are designed for small-medium businesses starting out with Azure Landing Zones. They are cost-optimized with reduced resource deployment. Identity and security subscriptions are recommended but optional in these scenarios.
+These scenarios are designed for small-medium businesses **only** (e.g. less than 10 workloads or less than 100/200 FTEs) that want to start with an Azure landing zone (ALZ) aligned platform landing zone but perhaps are not yet ready for the full scale of ALZ and the associated cost. However, they want to start on the right path and not pin themselves in to an architecture they cannot expand upon later. They are cost-optimized with reduced resource deployment, out of the box.
+
+Identity and security subscriptions are recommended but optional in these scenarios also.
 
 {{< hint type=warning >}}
 The SMB scenarios disable the DDoS Network Protection Plan to reduce costs. If you use these scenarios, you **MUST** consider and plan how to sufficiently protect your applications and workloads from DDoS attacks, like using [DDoS IP Protection](https://learn.microsoft.com/azure/ddos-protection/ddos-protection-sku-comparison), or an alternative solution.

--- a/docs/content/accelerator/starter-terraform/scenarios/_index.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/_index.md
@@ -8,12 +8,25 @@ Scenarios are common use cases when deploying the Platform landing zone. The fol
 
 The available scenarios are:
 
+### Full Scenarios
+
 1. [Multi-Region Hub and Spoke Virtual Network with Azure Firewall]({{< relref "multi-region-hub-and-spoke-vnet-with-azure-firewall" >}})
-1. [Multi-Region Virtual WAN with Azure Firewall]({{< relref "multi-region-virtual-wan-with-azure-firewall" >}})
-1. [Multi-Region Hub and Spoke Virtual Network with Network Virtual Appliance (NVA)]({{< relref "multi-region-hub-and-spoke-vnet-with-nva" >}})
-1. [Multi-Region Virtual WAN with Network Virtual Appliance (NVA)]({{< relref "multi-region-virtual-wan-with-nva" >}})
-1. [Management Groups, Policy and Management Resources Only]({{< relref "management-only" >}})
-1. [Single-Region Hub and Spoke Virtual Network with Azure Firewall]({{< relref "single-region-hub-and-spoke-vnet-with-azure-firewall" >}})
-1. [Single-Region Virtual WAN with Azure Firewall]({{< relref "single-region-virtual-wan-with-azure-firewall" >}})
-1. [Single-Region Hub and Spoke Virtual Network with Network Virtual Appliance (NVA)]({{< relref "single-region-hub-and-spoke-vnet-with-nva" >}})
-1. [Single-Region Virtual WAN with Network Virtual Appliance (NVA)]({{< relref "single-region-virtual-wan-with-nva" >}})
+2. [Multi-Region Virtual WAN with Azure Firewall]({{< relref "multi-region-virtual-wan-with-azure-firewall" >}})
+3. [Multi-Region Hub and Spoke Virtual Network with Network Virtual Appliance (NVA)]({{< relref "multi-region-hub-and-spoke-vnet-with-nva" >}})
+4. [Multi-Region Virtual WAN with Network Virtual Appliance (NVA)]({{< relref "multi-region-virtual-wan-with-nva" >}})
+5. [Management Groups, Policy and Management Resources Only]({{< relref "management-only" >}})
+6. [Single-Region Hub and Spoke Virtual Network with Azure Firewall]({{< relref "single-region-hub-and-spoke-vnet-with-azure-firewall" >}})
+7. [Single-Region Virtual WAN with Azure Firewall]({{< relref "single-region-virtual-wan-with-azure-firewall" >}})
+8. [Single-Region Hub and Spoke Virtual Network with Network Virtual Appliance (NVA)]({{< relref "single-region-hub-and-spoke-vnet-with-nva" >}})
+9. [Single-Region Virtual WAN with Network Virtual Appliance (NVA)]({{< relref "single-region-virtual-wan-with-nva" >}})
+
+### SMB (Small-Medium Business) Scenarios
+
+These scenarios are designed for small-medium businesses starting out with Azure Landing Zones. They are cost-optimized with reduced resource deployment. Identity and security subscriptions are recommended but optional in these scenarios.
+
+{{< hint type=warning >}}
+The SMB scenarios disable the DDoS Protection Plan to reduce costs. If you use these scenarios, you **MUST** implement [Azure DDoS IP Protection](https://learn.microsoft.com/azure/ddos-protection/ddos-protection-sku-comparison) on each public IP address to maintain security.
+{{< /hint >}}
+
+10. [SMB Single-Region Hub and Spoke Virtual Network with Azure Firewall]({{< relref "smb-single-region-hub-and-spoke-vnet-with-azure-firewall" >}})
+11. [SMB Single-Region Virtual WAN with Azure Firewall]({{< relref "smb-single-region-virtual-wan-with-azure-firewall" >}})

--- a/docs/content/accelerator/starter-terraform/scenarios/_index.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/_index.md
@@ -25,7 +25,7 @@ The available scenarios are:
 These scenarios are designed for small-medium businesses starting out with Azure Landing Zones. They are cost-optimized with reduced resource deployment. Identity and security subscriptions are recommended but optional in these scenarios.
 
 {{< hint type=warning >}}
-The SMB scenarios disable the DDoS Protection Plan to reduce costs. If you use these scenarios, you **MUST** implement [Azure DDoS IP Protection](https://learn.microsoft.com/azure/ddos-protection/ddos-protection-sku-comparison) on each public IP address to maintain security.
+The SMB scenarios disable the DDoS Network Protection Plan to reduce costs. If you use these scenarios, you **MUST** consider and plan how to sufficiently protect your applications and workloads from DDoS attacks, like using [DDoS IP Protection](https://learn.microsoft.com/azure/ddos-protection/ddos-protection-sku-comparison), or an alternative solution.
 {{< /hint >}}
 
 10. [SMB Single-Region Hub and Spoke Virtual Network with Azure Firewall]({{< relref "smb-single-region-hub-and-spoke-vnet-with-azure-firewall" >}})

--- a/docs/content/accelerator/starter-terraform/scenarios/management-only.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/management-only.md
@@ -27,3 +27,13 @@ The following resources are deployed by default in this scenario:
 - Log Analytics Data Collection Rules for AMA
 - User Assigned Managed Identity for AMA
 - Automation Account
+
+#### Subscription Placement
+
+{{< hint type=tip >}}
+**Identity and Security subscriptions are recommended but optional.** If you do not yet have dedicated subscriptions for identity and security workloads, you can comment out or remove the identity and security subscription placement blocks in the configuration file and add them later.
+{{< /hint >}}
+
+- Management subscription - placed under the `management` management group
+- Identity subscription - placed under the `identity` management group (recommended)
+- Security subscription - placed under the `security` management group (recommended)

--- a/docs/content/accelerator/starter-terraform/scenarios/multi-region-hub-and-spoke-vnet-with-azure-firewall.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/multi-region-hub-and-spoke-vnet-with-azure-firewall.md
@@ -28,7 +28,16 @@ The following resources are deployed by default in this scenario:
 - User Assigned Managed Identity for AMA
 - Automation Account
 
-### Connectivity
+#### Subscription Placement
+
+{{< hint type=tip >}}
+**Identity and Security subscriptions are recommended but optional.** If you do not yet have dedicated subscriptions for identity and security workloads, you can comment out or remove the identity and security subscription placement blocks in the configuration file and add them later.
+{{< /hint >}}
+
+- Connectivity subscription - placed under the `connectivity` management group
+- Management subscription - placed under the `management` management group
+- Identity subscription - placed under the `identity` management group (recommended)
+- Security subscription - placed under the `security` management group (recommended)
 
 #### Azure DDOS Protection Plan
 

--- a/docs/content/accelerator/starter-terraform/scenarios/multi-region-hub-and-spoke-vnet-with-nva.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/multi-region-hub-and-spoke-vnet-with-nva.md
@@ -28,7 +28,16 @@ The following resources are deployed by default in this scenario:
 - User Assigned Managed Identity for AMA
 - Automation Account
 
-### Connectivity
+#### Subscription Placement
+
+{{< hint type=tip >}}
+**Identity and Security subscriptions are recommended but optional.** If you do not yet have dedicated subscriptions for identity and security workloads, you can comment out or remove the identity and security subscription placement blocks in the configuration file and add them later.
+{{< /hint >}}
+
+- Connectivity subscription - placed under the `connectivity` management group
+- Management subscription - placed under the `management` management group
+- Identity subscription - placed under the `identity` management group (recommended)
+- Security subscription - placed under the `security` management group (recommended)
 
 #### Azure DDOS Protection Plan
 

--- a/docs/content/accelerator/starter-terraform/scenarios/multi-region-virtual-wan-with-azure-firewall.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/multi-region-virtual-wan-with-azure-firewall.md
@@ -28,7 +28,16 @@ The following resources are deployed by default in this scenario:
 - User Assigned Managed Identity for AMA
 - Automation Account
 
-### Connectivity
+#### Subscription Placement
+
+{{< hint type=tip >}}
+**Identity and Security subscriptions are recommended but optional.** If you do not yet have dedicated subscriptions for identity and security workloads, you can comment out or remove the identity and security subscription placement blocks in the configuration file and add them later.
+{{< /hint >}}
+
+- Connectivity subscription - placed under the `connectivity` management group
+- Management subscription - placed under the `management` management group
+- Identity subscription - placed under the `identity` management group (recommended)
+- Security subscription - placed under the `security` management group (recommended)
 
 #### Azure DDOS Protection Plan
 

--- a/docs/content/accelerator/starter-terraform/scenarios/multi-region-virtual-wan-with-nva.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/multi-region-virtual-wan-with-nva.md
@@ -28,7 +28,16 @@ The following resources are deployed by default in this scenario:
 - User Assigned Managed Identity for AMA
 - Automation Account
 
-### Connectivity
+#### Subscription Placement
+
+{{< hint type=tip >}}
+**Identity and Security subscriptions are recommended but optional.** If you do not yet have dedicated subscriptions for identity and security workloads, you can comment out or remove the identity and security subscription placement blocks in the configuration file and add them later.
+{{< /hint >}}
+
+- Connectivity subscription - placed under the `connectivity` management group
+- Management subscription - placed under the `management` management group
+- Identity subscription - placed under the `identity` management group (recommended)
+- Security subscription - placed under the `security` management group (recommended)
 
 #### Azure DDOS Protection Plan
 

--- a/docs/content/accelerator/starter-terraform/scenarios/single-region-hub-and-spoke-vnet-with-azure-firewall.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/single-region-hub-and-spoke-vnet-with-azure-firewall.md
@@ -32,7 +32,16 @@ The following resources are deployed by default in this scenario:
 - User Assigned Managed Identity for AMA
 - Automation Account
 
-### Connectivity
+#### Subscription Placement
+
+{{< hint type=tip >}}
+**Identity and Security subscriptions are recommended but optional.** If you do not yet have dedicated subscriptions for identity and security workloads, you can comment out or remove the identity and security subscription placement blocks in the configuration file and add them later.
+{{< /hint >}}
+
+- Connectivity subscription - placed under the `connectivity` management group
+- Management subscription - placed under the `management` management group
+- Identity subscription - placed under the `identity` management group (recommended)
+- Security subscription - placed under the `security` management group (recommended)
 
 #### Azure DDOS Protection Plan
 

--- a/docs/content/accelerator/starter-terraform/scenarios/single-region-hub-and-spoke-vnet-with-nva.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/single-region-hub-and-spoke-vnet-with-nva.md
@@ -32,7 +32,16 @@ The following resources are deployed by default in this scenario:
 - User Assigned Managed Identity for AMA
 - Automation Account
 
-### Connectivity
+#### Subscription Placement
+
+{{< hint type=tip >}}
+**Identity and Security subscriptions are recommended but optional.** If you do not yet have dedicated subscriptions for identity and security workloads, you can comment out or remove the identity and security subscription placement blocks in the configuration file and add them later.
+{{< /hint >}}
+
+- Connectivity subscription - placed under the `connectivity` management group
+- Management subscription - placed under the `management` management group
+- Identity subscription - placed under the `identity` management group (recommended)
+- Security subscription - placed under the `security` management group (recommended)
 
 #### Azure DDOS Protection Plan
 

--- a/docs/content/accelerator/starter-terraform/scenarios/single-region-virtual-wan-with-azure-firewall.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/single-region-virtual-wan-with-azure-firewall.md
@@ -32,7 +32,16 @@ The following resources are deployed by default in this scenario:
 - User Assigned Managed Identity for AMA
 - Automation Account
 
-### Connectivity
+#### Subscription Placement
+
+{{< hint type=tip >}}
+**Identity and Security subscriptions are recommended but optional.** If you do not yet have dedicated subscriptions for identity and security workloads, you can comment out or remove the identity and security subscription placement blocks in the configuration file and add them later.
+{{< /hint >}}
+
+- Connectivity subscription - placed under the `connectivity` management group
+- Management subscription - placed under the `management` management group
+- Identity subscription - placed under the `identity` management group (recommended)
+- Security subscription - placed under the `security` management group (recommended)
 
 #### Azure DDOS Protection Plan
 

--- a/docs/content/accelerator/starter-terraform/scenarios/single-region-virtual-wan-with-nva.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/single-region-virtual-wan-with-nva.md
@@ -32,7 +32,16 @@ The following resources are deployed by default in this scenario:
 - User Assigned Managed Identity for AMA
 - Automation Account
 
-### Connectivity
+#### Subscription Placement
+
+{{< hint type=tip >}}
+**Identity and Security subscriptions are recommended but optional.** If you do not yet have dedicated subscriptions for identity and security workloads, you can comment out or remove the identity and security subscription placement blocks in the configuration file and add them later.
+{{< /hint >}}
+
+- Connectivity subscription - placed under the `connectivity` management group
+- Management subscription - placed under the `management` management group
+- Identity subscription - placed under the `identity` management group (recommended)
+- Security subscription - placed under the `security` management group (recommended)
 
 #### Azure DDOS Protection Plan
 

--- a/docs/content/accelerator/starter-terraform/scenarios/smb-single-region-hub-and-spoke-vnet-with-azure-firewall.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/smb-single-region-hub-and-spoke-vnet-with-azure-firewall.md
@@ -71,7 +71,7 @@ The following resources are **not deployed** in this scenario to reduce costs:
 **DDoS Network Protection Plan is disabled in this scenario.** This means your public-facing resources are not protected by an Azure DDoS Network Protection Plan. Disabling it without an alternative may leave your applications and workloads vulnerable to DDoS attacks. You should weigh up the pros and cons of before deciding to disable the DDoS Network Protection Plan and also consider how you will protect your applications and services without it. You may decide the DDoS IP Protection offering per-Public IP is a suitable option, as detailed [here](https://learn.microsoft.com/azure/ddos-protection/ddos-protection-sku-comparison), or an alternative solution. 
 {{< /hint >}}
 
-- DDoS Protection Plan (see warning above - per-IP DDoS protection must be implemented as an alternative)
+- DDoS Protection Plan
 - ExpressRoute Gateway
 - Azure Bastion
 

--- a/docs/content/accelerator/starter-terraform/scenarios/smb-single-region-hub-and-spoke-vnet-with-azure-firewall.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/smb-single-region-hub-and-spoke-vnet-with-azure-firewall.md
@@ -6,7 +6,7 @@ weight: 10
 A cost-optimized Platform landing zone deployment designed for small-medium businesses (SMB) **only** (e.g. less than 10 workloads or less than 100/200 FTEs) that want to start with an Azure landing zone (ALZ) aligned platform landing zone but perhaps are not yet ready for the full scale of ALZ and the associated cost. This scenario uses hub and spoke Virtual Network connectivity with Azure Firewall (Basic SKU) in a single region.
 
 {{< hint type=tip >}}
-This scenario is designed to minimize costs while still providing a solid foundation for your Azure Landing Zone. As your organization grows, you can enable additional resources and expand to multiple regions.
+This scenario is designed to minimize costs while still providing a solid foundation for your Azure landing zone. As your organization grows, you can enable additional resources and expand to multiple regions easily without having to redeploy etc.
 {{< /hint >}}
 
 {{< hint type=warning >}}

--- a/docs/content/accelerator/starter-terraform/scenarios/smb-single-region-hub-and-spoke-vnet-with-azure-firewall.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/smb-single-region-hub-and-spoke-vnet-with-azure-firewall.md
@@ -3,7 +3,7 @@ title: 10 - SMB Single-Region Hub and Spoke Virtual Network with Azure Firewall
 weight: 10
 ---
 
-A cost-optimized Platform landing zone deployment designed for small-medium businesses (SMB) starting out with Azure Landing Zones. This scenario uses hub and spoke Virtual Network connectivity with Azure Firewall (Basic SKU) in a single region.
+A cost-optimized Platform landing zone deployment designed for small-medium businesses (SMB) **only** (e.g. less than 10 workloads or less than 100/200 FTEs) that want to start with an Azure landing zone (ALZ) aligned platform landing zone but perhaps are not yet ready for the full scale of ALZ and the associated cost. This scenario uses hub and spoke Virtual Network connectivity with Azure Firewall (Basic SKU) in a single region.
 
 {{< hint type=tip >}}
 This scenario is designed to minimize costs while still providing a solid foundation for your Azure Landing Zone. As your organization grows, you can enable additional resources and expand to multiple regions.

--- a/docs/content/accelerator/starter-terraform/scenarios/smb-single-region-hub-and-spoke-vnet-with-azure-firewall.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/smb-single-region-hub-and-spoke-vnet-with-azure-firewall.md
@@ -1,0 +1,110 @@
+---
+title: 10 - SMB Single-Region Hub and Spoke Virtual Network with Azure Firewall
+weight: 10
+---
+
+A cost-optimized Platform landing zone deployment designed for small-medium businesses (SMB) starting out with Azure Landing Zones. This scenario uses hub and spoke Virtual Network connectivity with Azure Firewall (Basic SKU) in a single region.
+
+{{< hint type=tip >}}
+This scenario is designed to minimize costs while still providing a solid foundation for your Azure Landing Zone. As your organization grows, you can enable additional resources and expand to multiple regions.
+{{< /hint >}}
+
+{{< hint type=warning >}}
+The single region option is here for completeness, we recommend always having at least 2 regions to support resiliency.
+{{< /hint >}}
+
+* Example Platform landing zone configuration file: [smb-single-region/hub-and-spoke-vnet.tfvars](https://raw.githubusercontent.com/Azure/alz-terraform-accelerator/refs/heads/main/templates/platform_landing_zone/examples/smb-single-region/hub-and-spoke-vnet.tfvars)
+
+## Resources
+
+The following resources are deployed by default in this scenario:
+
+### Management
+
+#### Management Groups
+
+- Management Groups
+- Policy Definitions
+- Policy Set Definitions
+- Policy Assignments
+- Policy Assignment Role Assignments
+
+#### Management Resources
+
+- Log Analytics Workspace
+- Log Analytics Data Collection Rules for AMA
+- User Assigned Managed Identity for AMA
+- Automation Account
+
+### Connectivity
+
+#### Azure Virtual Networks
+
+- Hub virtual network in one region
+- Subnets for Firewall, Gateway, and Private DNS Resolver in one region
+- Azure Route table for Firewall in one region
+- Azure Route table for other subnets and spokes in one region
+
+#### Azure Firewall
+
+- Azure Firewall (Basic SKU) in one region
+- Azure Firewall public IP in one region
+- Azure Firewall policy (Basic SKU) in one region
+
+#### Azure Private DNS
+
+- Azure Private DNS Resolver in one region
+- Azure non-regional Private Link Private DNS zones in one region
+- Azure regional Private Link Private DNS zones in one region
+- Azure Virtual Machine auto-registration Private DNS zone in one region
+- Azure Private Link DNS zone virtual network links in one region
+
+#### Azure Virtual Network Gateways
+
+- Azure VPN Virtual Network Gateway in one region
+
+### Resources Not Deployed (Cost Optimization)
+
+The following resources are **not deployed** in this scenario to reduce costs:
+
+{{< hint type=danger >}}
+**DDoS Protection Plan is disabled in this scenario.** This means your public-facing resources are not protected by an Azure DDoS Protection Plan. You **MUST** implement [Azure DDoS IP Protection](https://learn.microsoft.com/azure/ddos-protection/ddos-protection-sku-comparison) on each public IP address to maintain security. Failure to implement per-IP DDoS protection leaves your public-facing services vulnerable to DDoS attacks.
+{{< /hint >}}
+
+- DDoS Protection Plan (see warning above - per-IP DDoS protection must be implemented as an alternative)
+- ExpressRoute Gateway
+- Azure Bastion
+
+### Subscription Placement
+
+{{< hint type=tip >}}
+**Identity and Security subscriptions are recommended but optional.** The configuration has the identity and security subscription placements commented out. When you are ready to add dedicated subscriptions for identity and security workloads, uncomment the relevant blocks in the configuration file and supply the subscription IDs.
+{{< /hint >}}
+
+- Connectivity subscription - placed under the `connectivity` management group
+- Management subscription - placed under the `management` management group
+- Identity subscription - **commented out** (uncomment when ready)
+- Security subscription - **commented out** (uncomment when ready)
+
+## Configuration
+
+The following relevant configuration is applied:
+
+### Azure DNS
+
+Private DNS is configured ready for using Private Link and Virtual Machine Auto-registration. Spoke Virtual Networks should use the Azure Firewall IP Address as their DNS configuration.
+
+- Azure Firewall is configured as DNS proxy
+- Azure Firewall forwards DNS traffic to the Private DNS resolver
+- Azure Private DNS Resolver has an inbound endpoint from the hub network
+- Azure Private Link DNS zones are linked to the all hub Virtual Networks
+
+### Azure Routing
+
+Route tables are pre-configured for spoke virtual networks in one region. Assign the user subnet route table to any subnets created in spokes.
+
+- Azure Firewall in one region as next hop in Route Table
+
+### DDoS Policy
+
+- The `Enable-DDoS-VNET` policy assignment is set to `DoNotEnforce` on the `connectivity` and `landingzones` management groups, since DDoS Protection Plan is not deployed.

--- a/docs/content/accelerator/starter-terraform/scenarios/smb-single-region-hub-and-spoke-vnet-with-azure-firewall.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/smb-single-region-hub-and-spoke-vnet-with-azure-firewall.md
@@ -68,7 +68,7 @@ The following resources are deployed by default in this scenario:
 The following resources are **not deployed** in this scenario to reduce costs:
 
 {{< hint type=danger >}}
-**DDoS Protection Plan is disabled in this scenario.** This means your public-facing resources are not protected by an Azure DDoS Protection Plan. You **MUST** implement [Azure DDoS IP Protection](https://learn.microsoft.com/azure/ddos-protection/ddos-protection-sku-comparison) on each public IP address to maintain security. Failure to implement per-IP DDoS protection leaves your public-facing services vulnerable to DDoS attacks.
+**DDoS Network Protection Plan is disabled in this scenario.** This means your public-facing resources are not protected by an Azure DDoS Network Protection Plan. Disabling it without an alternative may leave your applications and workloads vulnerable to DDoS attacks. You should weigh up the pros and cons of before deciding to disable the DDoS Network Protection Plan and also consider how you will protect your applications and services without it. You may decide the DDoS IP Protection offering per-Public IP is a suitable option, as detailed [here](https://learn.microsoft.com/azure/ddos-protection/ddos-protection-sku-comparison), or an alternative solution. 
 {{< /hint >}}
 
 - DDoS Protection Plan (see warning above - per-IP DDoS protection must be implemented as an alternative)

--- a/docs/content/accelerator/starter-terraform/scenarios/smb-single-region-virtual-wan-with-azure-firewall.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/smb-single-region-virtual-wan-with-azure-firewall.md
@@ -3,7 +3,7 @@ title: 11 - SMB Single-Region Virtual WAN with Azure Firewall
 weight: 11
 ---
 
-A cost-optimized Platform landing zone deployment designed for small-medium businesses (SMB) starting out with Azure Landing Zones. This scenario uses Virtual WAN network connectivity with Azure Firewall (Basic SKU) in a single region.
+A cost-optimized Platform landing zone deployment designed for small-medium businesses (SMB) **only** (e.g. less than 10 workloads or less than 100/200 FTEs) that want to start with an Azure landing zone (ALZ) aligned platform landing zone but perhaps are not yet ready for the full scale of ALZ and the associated cost. . This scenario uses Virtual WAN network connectivity with Azure Firewall (Basic SKU) in a single region.
 
 {{< hint type=tip >}}
 This scenario is designed to minimize costs while still providing a solid foundation for your Azure Landing Zone. As your organization grows, you can enable additional resources and expand to multiple regions.

--- a/docs/content/accelerator/starter-terraform/scenarios/smb-single-region-virtual-wan-with-azure-firewall.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/smb-single-region-virtual-wan-with-azure-firewall.md
@@ -1,0 +1,108 @@
+---
+title: 11 - SMB Single-Region Virtual WAN with Azure Firewall
+weight: 11
+---
+
+A cost-optimized Platform landing zone deployment designed for small-medium businesses (SMB) starting out with Azure Landing Zones. This scenario uses Virtual WAN network connectivity with Azure Firewall (Basic SKU) in a single region.
+
+{{< hint type=tip >}}
+This scenario is designed to minimize costs while still providing a solid foundation for your Azure Landing Zone. As your organization grows, you can enable additional resources and expand to multiple regions.
+{{< /hint >}}
+
+{{< hint type=warning >}}
+The single region option is here for completeness, we recommend always having at least 2 regions to support resiliency.
+{{< /hint >}}
+
+* Example Platform landing zone configuration file: [smb-single-region/virtual-wan.tfvars](https://raw.githubusercontent.com/Azure/alz-terraform-accelerator/refs/heads/main/templates/platform_landing_zone/examples/smb-single-region/virtual-wan.tfvars)
+
+## Resources
+
+The following resources are deployed by default in this scenario:
+
+### Management
+
+#### Management Groups
+
+- Management Groups
+- Policy Definitions
+- Policy Set Definitions
+- Policy Assignments
+- Policy Assignment Role Assignments
+
+#### Management Resources
+
+- Log Analytics Workspace
+- Log Analytics Data Collection Rules for AMA
+- User Assigned Managed Identity for AMA
+- Automation Account
+
+### Connectivity
+
+#### Azure Virtual WAN
+
+- Virtual WAN homed in one region
+- Virtual Hub in one region
+
+#### Azure Virtual Networks
+
+- Sidecar Virtual Network
+- Sidecar to Virtual Hub peering
+- Subnets for Private DNS Resolver in one region
+
+#### Azure Firewall
+
+- Azure Firewall (Basic SKU) in one region
+- Azure Firewall public IP in one region
+- Azure Firewall policy (Basic SKU) in one region
+
+#### Azure Private DNS
+
+- Azure Private DNS Resolver in one region
+- Azure non-regional Private Link Private DNS zones in one region
+- Azure regional Private Link Private DNS zones in one region
+- Azure Virtual Machine auto-registration Private DNS zone in one region
+- Azure Private Link DNS zone virtual network links in one region
+
+#### Azure Virtual Network Gateways
+
+- Azure VPN Virtual Network Gateway in one region
+
+### Resources Not Deployed (Cost Optimization)
+
+The following resources are **not deployed** in this scenario to reduce costs:
+
+{{< hint type=danger >}}
+**DDoS Protection Plan is disabled in this scenario.** This means your public-facing resources are not protected by an Azure DDoS Protection Plan. You **MUST** implement [Azure DDoS IP Protection](https://learn.microsoft.com/azure/ddos-protection/ddos-protection-sku-comparison) on each public IP address to maintain security. Failure to implement per-IP DDoS protection leaves your public-facing services vulnerable to DDoS attacks.
+{{< /hint >}}
+
+- DDoS Protection Plan (see warning above - per-IP DDoS protection must be implemented as an alternative)
+- ExpressRoute Gateway
+- Azure Bastion
+
+### Subscription Placement
+
+{{< hint type=tip >}}
+**Identity and Security subscriptions are recommended but optional.** The configuration has the identity and security subscription placements commented out. When you are ready to add dedicated subscriptions for identity and security workloads, uncomment the relevant blocks in the configuration file and supply the subscription IDs.
+{{< /hint >}}
+
+- Connectivity subscription - placed under the `connectivity` management group
+- Management subscription - placed under the `management` management group
+- Identity subscription - **commented out** (uncomment when ready)
+- Security subscription - **commented out** (uncomment when ready)
+
+## Configuration
+
+The following relevant configuration is applied:
+
+### Azure DNS
+
+Private DNS is configured ready for using Private Link and Virtual Machine Auto-registration. Spoke Virtual Networks should use the Azure Firewall IP Address as their DNS configuration.
+
+- Azure Firewall is configured as DNS proxy
+- Azure Firewall forwards DNS traffic to the Private DNS resolver
+- Azure Private DNS Resolver has an inbound endpoint from the sidecar network
+- Azure Private Link DNS zones are linked to the all hub sidecar Virtual Networks
+
+### DDoS Policy
+
+- The `Enable-DDoS-VNET` policy assignment is set to `DoNotEnforce` on the `connectivity` and `landingzones` management groups, since DDoS Protection Plan is not deployed.

--- a/docs/content/accelerator/starter-terraform/scenarios/smb-single-region-virtual-wan-with-azure-firewall.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/smb-single-region-virtual-wan-with-azure-firewall.md
@@ -6,7 +6,7 @@ weight: 11
 A cost-optimized Platform landing zone deployment designed for small-medium businesses (SMB) **only** (e.g. less than 10 workloads or less than 100/200 FTEs) that want to start with an Azure landing zone (ALZ) aligned platform landing zone but perhaps are not yet ready for the full scale of ALZ and the associated cost. . This scenario uses Virtual WAN network connectivity with Azure Firewall (Basic SKU) in a single region.
 
 {{< hint type=tip >}}
-This scenario is designed to minimize costs while still providing a solid foundation for your Azure Landing Zone. As your organization grows, you can enable additional resources and expand to multiple regions.
+This scenario is designed to minimize costs while still providing a solid foundation for your Azure landing zone. As your organization grows, you can enable additional resources and expand to multiple regions easily without having to redeploy etc.
 {{< /hint >}}
 
 {{< hint type=warning >}}

--- a/docs/content/accelerator/starter-terraform/scenarios/smb-single-region-virtual-wan-with-azure-firewall.md
+++ b/docs/content/accelerator/starter-terraform/scenarios/smb-single-region-virtual-wan-with-azure-firewall.md
@@ -72,7 +72,7 @@ The following resources are deployed by default in this scenario:
 The following resources are **not deployed** in this scenario to reduce costs:
 
 {{< hint type=danger >}}
-**DDoS Protection Plan is disabled in this scenario.** This means your public-facing resources are not protected by an Azure DDoS Protection Plan. You **MUST** implement [Azure DDoS IP Protection](https://learn.microsoft.com/azure/ddos-protection/ddos-protection-sku-comparison) on each public IP address to maintain security. Failure to implement per-IP DDoS protection leaves your public-facing services vulnerable to DDoS attacks.
+**DDoS Network Protection Plan is disabled in this scenario.** This means your public-facing resources are not protected by an Azure DDoS Network Protection Plan. Disabling it without an alternative may leave your applications and workloads vulnerable to DDoS attacks. You should weigh up the pros and cons of before deciding to disable the DDoS Network Protection Plan and also consider how you will protect your applications and services without it. You may decide the DDoS IP Protection offering per-Public IP is a suitable option, as detailed [here](https://learn.microsoft.com/azure/ddos-protection/ddos-protection-sku-comparison), or an alternative solution. 
 {{< /hint >}}
 
 - DDoS Protection Plan (see warning above - per-IP DDoS protection must be implemented as an alternative)


### PR DESCRIPTION
## Summary

https://github.com/Azure/Azure-Landing-Zones/issues/4095

- **New SMB scenarios**: Added two new cost-optimized scenarios for small-medium businesses:
  - SMB Single-Region Hub and Spoke Virtual Network with Azure Firewall
  - SMB Single-Region Virtual WAN with Azure Firewall

- **Identity and Security subscriptions marked as optional**: Added notes to all scenario docs (including full, single-region, multi-region, and management-only) clarifying that identity and security subscriptions are recommended but optional. Users can comment them out and add them later.

- **DDoS warnings**: Added clear danger-level warnings in the SMB scenario docs and the DDoS options doc that disabling the DDoS Protection Plan opens up a security risk and that per-IP DDoS protection **must** be implemented on every public IP address to stay secure.

## Changes

### New files
- \docs/content/accelerator/starter-terraform/scenarios/smb-single-region-hub-and-spoke-vnet-with-azure-firewall.md\
- \docs/content/accelerator/starter-terraform/scenarios/smb-single-region-virtual-wan-with-azure-firewall.md\

### Modified files
- \docs/content/accelerator/starter-terraform/scenarios/_index.md\ - Added SMB scenarios section with DDoS warning
- \docs/content/accelerator/starter-terraform/options/ddos.md\ - Upgraded warning to danger level with stronger language
- All 9 existing scenario docs - Added subscription placement section noting identity/security as optional

Related to: https://github.com/Azure/alz-terraform-accelerator/pull/305