### PR TITLE
fix(issue-triage): improve agentic workflow prompt and fix label application

### DIFF
--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -22,7 +22,7 @@
 #
 # Automated issue triage for Azure Landing Zones. Checks for duplicates, suggests labels, and posts a triage summary comment on new or reopened issues.
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7c1a8731e3cae43e6826b35de5e7a90a8d0291c040087ebd24124a4e753f7b4f","compiler_version":"v0.63.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3663a2163efcd582907a43861930b5cc25c0a6e286cde184c2a9440032c8d48a","compiler_version":"v0.63.0","strict":true,"agent_id":"copilot"}
 
 name: "Azure Landing Zones — Automated Issue Triage"
 "on":
@@ -149,7 +149,7 @@ jobs:
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
           cat << 'GH_AW_PROMPT_EOF'
           <safe-output-tools>
-          Tools: add_comment, close_issue, update_issue, missing_tool, missing_data, noop
+          Tools: add_comment, close_issue, update_issue, add_labels, missing_tool, missing_data, noop
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -366,7 +366,7 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"add_comment":{"max":1},"close_issue":{"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1},"update_issue":{"max":1}}
+          {"add_comment":{"max":1},"add_labels":{"max":10},"close_issue":{"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1},"update_issue":{"max":1}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
       - name: Write Safe Outputs Tools
         run: |
@@ -374,6 +374,7 @@ jobs:
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added.",
+              "add_labels": " CONSTRAINTS: Maximum 10 label(s) can be added.",
               "close_issue": " CONSTRAINTS: Maximum 1 issue(s) can be closed.",
               "update_issue": " CONSTRAINTS: Maximum 1 issue(s) can be updated."
             },
@@ -394,6 +395,25 @@ jobs:
                 },
                 "item_number": {
                   "issueOrPRNumber": true
+                },
+                "repo": {
+                  "type": "string",
+                  "maxLength": 256
+                }
+              }
+            },
+            "add_labels": {
+              "defaultMax": 5,
+              "fields": {
+                "item_number": {
+                  "issueNumberOrTemporaryId": true
+                },
+                "labels": {
+                  "required": true,
+                  "type": "array",
+                  "itemType": "string",
+                  "itemSanitize": true,
+                  "itemMaxLength": 128
                 },
                 "repo": {
                   "type": "string",
@@ -1116,7 +1136,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"close_issue\":{\"max\":1},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"update_issue\":{\"allow_body\":true,\"max\":1}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"add_labels\":{\"max\":10},\"close_issue\":{\"max\":1},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"update_issue\":{\"allow_body\":true,\"max\":1}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -22,7 +22,7 @@
 #
 # Automated issue triage for Azure Landing Zones. Checks for duplicates, suggests labels, and posts a triage summary comment on new or reopened issues.
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3663a2163efcd582907a43861930b5cc25c0a6e286cde184c2a9440032c8d48a","compiler_version":"v0.63.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4cdfa4946fa86e566833d9b376e49d4002fce35193e0458e55fff775e56e28e9","compiler_version":"v0.63.0","strict":true,"agent_id":"copilot"}
 
 name: "Azure Landing Zones — Automated Issue Triage"
 "on":
@@ -78,7 +78,7 @@ jobs:
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
-          GH_AW_INFO_ALLOWED_DOMAINS: '["defaults","github"]'
+          GH_AW_INFO_ALLOWED_DOMAINS: '["defaults","github","learn.microsoft.com"]'
           GH_AW_INFO_FIREWALL_ENABLED: "true"
           GH_AW_INFO_AWF_VERSION: "v0.25.0"
           GH_AW_INFO_AWMG_VERSION: ""
@@ -638,6 +638,20 @@ jobs:
                   }
                 }
               },
+              "microsoftdocs": {
+                "type": "http",
+                "url": "https://learn.microsoft.com/api/mcp",
+                "tools": [
+                  "*"
+                ],
+                "guard-policies": {
+                  "write-sink": {
+                    "accept": [
+                      "*"
+                    ]
+                  }
+                }
+              },
               "safeoutputs": {
                 "type": "http",
                 "url": "http://host.docker.internal:$GH_AW_SAFE_OUTPUTS_PORT",
@@ -677,7 +691,7 @@ jobs:
           set -o pipefail
           touch /tmp/gh-aw/agent-step-summary.md
           # shellcheck disable=SC1003
-          sudo -E awf --env-all --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --allow-domains "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com" --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --enable-host-access --image-tag 0.25.0 --skip-pull --enable-api-proxy \
+          sudo -E awf --env-all --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --allow-domains "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,learn.microsoft.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com" --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --enable-host-access --image-tag 0.25.0 --skip-pull --enable-api-proxy \
             -- /bin/bash -c '/usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --add-dir "${GITHUB_WORKSPACE}" --disable-builtin-mcps --allow-all-tools --add-dir /tmp/gh-aw/cache-memory/ --allow-all-paths --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
@@ -775,7 +789,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
-          GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
+          GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,learn.microsoft.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
         with:
@@ -1133,7 +1147,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
+          GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,learn.microsoft.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
           GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"add_labels\":{\"max\":10},\"close_issue\":{\"max\":1},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"update_issue\":{\"allow_body\":true,\"max\":1}}"

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -22,7 +22,7 @@
 #
 # Automated issue triage for Azure Landing Zones. Checks for duplicates, suggests labels, and posts a triage summary comment on new or reopened issues.
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4cdfa4946fa86e566833d9b376e49d4002fce35193e0458e55fff775e56e28e9","compiler_version":"v0.63.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5bd47c7c8b04ef79d2aa11c3a2d1c4b8de1e7e503d807db6156adc1e39b6a8af","compiler_version":"v0.63.0","strict":true,"agent_id":"copilot"}
 
 name: "Azure Landing Zones — Automated Issue Triage"
 "on":

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -1,45 +1,51 @@
 ---
-description: >
-  Automated issue triage for Azure Landing Zones. Checks for duplicates,
-  suggests labels, and posts a triage summary comment on new or reopened issues.
-on:
+description: |
+  Automated issue triage for Azure Landing Zones. Checks for duplicates, suggests labels, and posts a triage summary comment on new or reopened issues.
+network:
+  allowed:
+  - defaults
+  - github
+  - learn.microsoft.com
+"on":
   issues:
-    types: [opened, reopened]
-  workflow_dispatch:
+    types:
+    - opened
+    - reopened
   roles: all
+  workflow_dispatch: null
 permissions:
   contents: read
   issues: read
   pull-requests: read
-tools:
-  github:
-    toolsets: [default]
-  web-fetch:
-  cache-memory: true
-network:
-  allowed:
-    - defaults
-    - github
 safe-outputs:
   add-comment:
     max: 1
   add-labels:
     max: 10
-  update-issue:
-    max: 1
   close-issue:
     max: 1
   noop:
     max: 1
+  update-issue:
+    max: 1
 steps:
-  - name: Fetch label definitions
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    run: |
-      mkdir -p /tmp/gh-aw/agent
-      gh api repos/${{ github.repository }}/labels --paginate --jq '[.[] | {name, description}]' > /tmp/gh-aw/agent/repo-labels.json
+- env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  name: Fetch label definitions
+  run: |
+    mkdir -p /tmp/gh-aw/agent
+    gh api repos/${{ github.repository }}/labels --paginate --jq '[.[] | {name, description}]' > /tmp/gh-aw/agent/repo-labels.json
+tools:
+  cache-memory: true
+  github:
+    toolsets:
+    - default
+  web-fetch: null
+mcp-servers:
+  microsoftdocs:
+    url: "https://learn.microsoft.com/api/mcp"
+    allowed: ["*"]
 ---
-
 # Azure Landing Zones — Automated Issue Triage
 
 You are an AI agent that performs initial triage on newly created or reopened issues in the **Azure/Azure-Landing-Zones** repository. This repository is the centralised documentation hub and issue tracker for the entire Azure Landing Zones (ALZ) ecosystem.

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -246,6 +246,11 @@ Once you have identified what the issue is about and which product/repo it relat
 ### Investigation Guidelines
 
 - Use the GitHub MCP tools to read files, search code, and list commits in the relevant public repo.
+- Use the **Microsoft Docs MCP** (`microsoftdocs`) to query official Azure and Cloud Adoption Framework (CAF) documentation when you need to:
+  - Verify expected Azure service behaviour (e.g., "is this how Azure Policy assignment inheritance is supposed to work?")
+  - Look up ALZ architecture guidance or design recommendations from `learn.microsoft.com`
+  - Determine whether a reported behaviour is a bug vs. expected/by-design per Microsoft documentation
+  - Ground your understanding of a feature request against the official ALZ guidance
 - Look for the specific module, file, variable, or resource referenced in the issue.
 - If you can identify a likely root cause or a specific file/line that may need changing, include that in your triage comment as a suggested fix.
 - **Keep suggestions brief and actionable** — e.g., "The variable `x` in `modules/foo/variables.tf` appears to be missing a default value" or "The policy assignment in `platform/alz/policy_assignments/` may need updating".
@@ -269,5 +274,6 @@ Once you have identified what the issue is about and which product/repo it relat
 - This repository is a **documentation and issue tracker** — it does not contain deployable IaC code.
 - Issues are often filed here that relate to code in **other ecosystem repos** (e.g., `alz-terraform-accelerator`, `ALZ-Bicep`, `Enterprise-Scale`). Apply the appropriate Product label even though the code lives elsewhere.
 - All ALZ ecosystem repositories are **public** — you can read their code, search for files, and list commits using the GitHub MCP tools. Use this to investigate issues and suggest fixes.
+- The **Microsoft Docs MCP** (`microsoftdocs`) gives you access to official Azure and CAF documentation on `learn.microsoft.com`. Use it to ground your answers in authoritative guidance, especially for architecture/design questions.
 - **Never create issues, PRs, or comments in other repos.** All write operations are limited to this repository.
 - Be conservative with duplicate detection. False positives (wrongly closing a valid issue) are much worse than false negatives (leaving a non-duplicate open).

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -24,8 +24,6 @@ safe-outputs:
     max: 10
   close-issue:
     max: 1
-  noop:
-    max: 1
   update-issue:
     max: 1
 steps:
@@ -59,7 +57,7 @@ When a new issue is created or reopened, perform the following steps **in order*
 3. **Suggest and attach labels** — Based on the issue content, attach appropriate labels that already exist on the repository.
 4. **Check for existing fixes** — Check recent releases and merged PRs in the relevant ecosystem repo to see if the issue has already been resolved.
 5. **Investigate and suggest a fix** — Where possible, look at the relevant source code in ecosystem repos and suggest what the fix may be. If the issue is a question or a consideration rather than a bug, that's fine — note it as such.
-6. **Post a triage summary comment** — Summarise what you did in a single comment on the issue.
+6. **Post a triage summary comment** — Summarise what you did in a single comment on the issue. **Do not emit any safe outputs until all analysis steps are complete.**
 
 ---
 
@@ -79,7 +77,7 @@ Search for existing issues (both open and closed) in **Azure/Azure-Landing-Zones
 
 ### Duplicate Handling Rules
 
-- **Exact duplicate (very high confidence):** If you find an issue that is clearly the same problem with the same context and you are very confident it is a complete and accurate match, close **this** issue as a duplicate. Use the `close-issue` safe output with a `not_planned` state reason. In your triage comment, link to the original issue and explain why you are closing this one.
+- **Exact duplicate (very high confidence):** If you find an issue that is clearly the same problem with the same context and you are very confident it is a complete and accurate match, you will close **this** issue as a duplicate. First post your triage comment (see Step 6 — Duplicate Closure Flow) explaining the match and linking to the original issue, then use the `close-issue` safe output with a `not_planned` state reason.
 - **Similar issues (partial match or related):** If you find issues that are related but not exact duplicates, **do NOT close this issue**. Instead, mention the similar issues in your triage comment so the human triagers are aware.
 - **No duplicates found:** Note this in your triage comment.
 
@@ -89,7 +87,7 @@ Search for existing issues (both open and closed) in **Azure/Azure-Landing-Zones
 
 ## Step 3: Suggest and Attach Labels
 
-The repository label definitions are available at `/tmp/gh-aw/agent/repo-labels.json`.
+The repository label definitions are available at `/tmp/gh-aw/agent/repo-labels.json`. If this file is missing or unreadable, skip label application and note in your triage comment that labels could not be applied due to a data loading error.
 
 Analyse the issue content and attach the most appropriate labels from the repository's existing label set. Apply **all** labels that are relevant.
 
@@ -97,7 +95,7 @@ Analyse the issue content and attach the most appropriate labels from the reposi
 
 Use the issue content to determine appropriate labels from these categories:
 
-**Product labels** (which component/path is affected — apply ONE primary product label):
+**Product labels** (which component/path is affected — apply all that are relevant):
 
 | Clue in issue | Label to apply |
 |---|---|
@@ -145,9 +143,76 @@ Use the issue content to determine appropriate labels from these categories:
 
 ---
 
-## Step 4: Post a Triage Summary Comment
+## Step 4: Check for Existing Fixes
 
-ALWAYS post **exactly one** comment on the issue using the `add-comment` safe output. The comment must follow this exact format:
+Before investigating a fix, check whether the issue has **already been resolved** in a recent release or merged PR. Users frequently raise issues for problems that have already been fixed but they haven't upgraded to the latest version.
+
+Using the GitHub MCP tools on the relevant ecosystem repository (see the Ecosystem Repository Map in Step 5):
+
+1. **Check recent releases** — List the last few releases in the relevant repo. Review the release notes / changelogs for mentions of the reported problem, related keywords, or the specific file/module/policy referenced in the issue.
+2. **Check recently merged PRs** — Search for recently merged PRs (last ~30 days) in the relevant repo that relate to the issue topic. Look at PR titles, descriptions, and changed files.
+3. **Check recent commits on the default branch** — If no release or PR match is found, check recent commits on the repository's default branch for relevant fixes that may not yet be in a release.
+
+### If a fix already exists
+
+- Note the specific release version or merged PR that contains the fix.
+- In your triage comment, tell the user that this appears to have been addressed and recommend they upgrade to the specified version.
+- **Do NOT close the issue** — leave it open for the human triage team to confirm and close. But you may suggest closing it if the fix is clear-cut.
+
+### If no existing fix is found
+
+- Proceed to Step 5 to investigate and suggest a fix.
+
+---
+
+## Step 5: Investigate and Suggest a Fix
+
+Once you have identified what the issue is about and which product/repo it relates to, attempt to investigate the root cause by reading relevant source code from the appropriate **public** ecosystem repository.
+
+### Ecosystem Repository Map
+
+| Product label | Repository to investigate |
+|---|---|
+| `Product: Terraform (AVM)` | `Azure/terraform-azurerm-avm-ptn-alz` |
+| `Product: ALZ Provider (Terraform)` | `Azure/terraform-provider-alz` |
+| `Product: Accelerator :zap:` + Terraform clues (`.tf`, `.tfvars`, module refs, starter templates) | `Azure/alz-terraform-accelerator` |
+| `Product: Accelerator :zap:` + Bootstrap clues (OIDC, state storage, managed identity, CI/CD, GitHub/ADO setup) | `Azure/accelerator-bootstrap-modules` |
+| `Product: Accelerator :zap:` + Bicep clues (`.bicep`, YAML config, Bicep registry modules) | `Azure/alz-bicep-accelerator` |
+| `Product: Bicep (AVM)` | `Azure/alz-bicep-accelerator` |
+| `Product: Bicep (Classic)` | `Azure/ALZ-Bicep` |
+| `Product: Azure Policy :shield:` | `Azure/Enterprise-Scale` and `Azure/Azure-Landing-Zones-Library` |
+| `Product: Library` | `Azure/Azure-Landing-Zones-Library` |
+| `Product: ALZ PowerShell` | `Azure/ALZ-PowerShell-Module` |
+| `Product: Portal` | `Azure/Enterprise-Scale` |
+| `Product: Terraform (Classic)` | `Azure/terraform-azurerm-caf-enterprise-scale` |
+| `Area: Documentation :page_facing_up:` | `Azure/Azure-Landing-Zones` (this repository) |
+| Hub & spoke networking | `Azure/terraform-azurerm-avm-ptn-alz-connectivity-hub-and-spoke-vnet` |
+| Virtual WAN networking | `Azure/terraform-azurerm-avm-ptn-alz-connectivity-virtual-wan` |
+| Private DNS zones | `Azure/terraform-azurerm-avm-ptn-network-private-link-private-dns-zones` |
+
+### Investigation Guidelines
+
+- Use the GitHub MCP tools to read files, search code, and list commits in the relevant public repo.
+- For issues about this repository's documentation, Hugo site, or workflows, investigate **this** repository (`Azure/Azure-Landing-Zones`) directly.
+- Use the **Microsoft Docs MCP** (`microsoftdocs`) to query official Azure and Cloud Adoption Framework (CAF) documentation when you need to:
+  - Verify expected Azure service behaviour (e.g., "is this how Azure Policy assignment inheritance is supposed to work?")
+  - Look up ALZ architecture guidance or design recommendations from `learn.microsoft.com`
+  - Determine whether a reported behaviour is a bug vs. expected/by-design per Microsoft documentation
+  - Ground your understanding of a feature request against the official ALZ guidance
+- Look for the specific module, file, variable, or resource referenced in the issue.
+- If you can identify a likely root cause or a specific file/line that may need changing, include that in your triage comment as a suggested fix.
+- **Keep suggestions brief and actionable** — e.g., "The variable `x` in `modules/foo/variables.tf` appears to be missing a default value" or "The policy assignment in `platform/alz/policy_assignments/` may need updating".
+- If the issue is a **question, feature request, or consideration** rather than a bug, that is perfectly fine. Note it as such in your triage comment — e.g., "This appears to be a question about configuration options rather than a bug" or "This is a feature request for consideration by the team".
+- If you **cannot** identify a likely fix (the issue is unclear, too complex, or you lack context), simply state that further investigation is needed. Do not speculate.
+- **Never create PRs, issues, or comments in other repos.** Your output is limited to the triage comment on this issue.
+
+---
+
+## Step 6: Post a Triage Summary Comment
+
+**Do not emit any safe outputs until ALL analysis steps (Steps 1–5) are complete.**
+
+ALWAYS post **exactly one** comment on the issue using the `add-comment` safe output, even if no triage actions were taken. The comment must follow this exact format:
 
 ```
 ## 🤖 GitHub Agentic Workflow Automated Triage 🤖
@@ -155,21 +220,36 @@ ALWAYS post **exactly one** comment on the issue using the `add-comment` safe ou
 <summary of actions as bullet points>
 ```
 
+If the issue has already been triaged or there is genuinely nothing to add, post:
+
+```
+## 🤖 GitHub Agentic Workflow Automated Triage 🤖
+
+- Issue assessed, no input from GitHub agentic workflow agent.
+```
+
 The bullet points should include:
 
 - **Duplicate check result:** Whether duplicates or similar issues were found, with links to those issues. If closing as duplicate, state this clearly with the link.
 - **Labels applied:** List the labels you attached and a brief justification for each (e.g., "Applied `Product: Terraform (AVM)` — issue references `avm-ptn-alz` module").
 - **No labels applied:** If no labels could be confidently determined, state this.
+- **Labels skipped:** If label definitions could not be loaded, state "Labels could not be applied due to a data loading error."
 - **Suggested fix:** If you identified a likely root cause or potential fix from investigating the source code, include it with specific file/line references. If the issue is a question or consideration rather than a bug, note that. If you could not determine a fix, state that further investigation is needed.
 - **Already fixed:** If a recent release or merged PR already addresses this issue, tell the user which version or PR contains the fix and recommend they upgrade.
 
 Keep the comment concise and factual. Do not speculate or add unnecessary detail.
 
-When closing an issue as a duplicate, always append the following note at the end of the comment:
+### Duplicate Closure Flow
 
-```
-> **Note:** If you believe this issue was incorrectly closed, please feel free to reopen it. We welcome feedback and will review reopened issues to improve our automated triage process.
-```
+When you are very confident an issue is an exact duplicate (see Step 2), follow this exact sequence:
+
+1. **First**, post your triage comment using `add-comment`. The comment MUST include a note advising the issue creator to reopen if the closure was incorrect:
+
+   ```
+   > **Note:** If you believe this issue was incorrectly closed as a duplicate, please reopen it and explain how it differs from the linked issue.
+   ```
+
+2. **Then**, close the issue using `close-issue` with state reason `not_planned`.
 
 ### Example Comment (not a duplicate)
 
@@ -192,80 +272,19 @@ When closing an issue as a duplicate, always append the following note at the en
   - `Product: Azure Policy :shield:` — issue is about a policy assignment error
   - `Topic: Policy :pencil:` — issue relates to policy definitions
 
-> **Note:** If you believe this issue was incorrectly closed, please feel free to reopen it. We welcome feedback and will review reopened issues to improve our automated triage process.
+> **Note:** If you believe this issue was incorrectly closed as a duplicate, please reopen it and explain how it differs from the linked issue.
 ```
-
----
-
-## Step 5: Check for Existing Fixes
-
-Before investigating a fix, check whether the issue has **already been resolved** in a recent release or merged PR. Users frequently raise issues for problems that have already been fixed but they haven't upgraded to the latest version.
-
-Using the GitHub MCP tools on the relevant ecosystem repository (see the Ecosystem Repository Map in Step 6):
-
-1. **Check recent releases** — List the last few releases in the relevant repo. Review the release notes / changelogs for mentions of the reported problem, related keywords, or the specific file/module/policy referenced in the issue.
-2. **Check recently merged PRs** — Search for recently merged PRs (last ~30 days) in the relevant repo that relate to the issue topic. Look at PR titles, descriptions, and changed files.
-3. **Check recent commits on the default branch** — If no release or PR match is found, check recent commits on `main` for relevant fixes that may not yet be in a release.
-
-### If a fix already exists
-
-- Note the specific release version or merged PR that contains the fix.
-- In your triage comment, tell the user that this appears to have been addressed and recommend they upgrade to the specified version.
-- **Do NOT close the issue** — leave it open for the human triage team to confirm and close. But you may suggest closing it if the fix is clear-cut.
-
-### If no existing fix is found
-
-- Proceed to Step 6 to investigate and suggest a fix.
-
----
-
-## Step 6: Investigate and Suggest a Fix
-
-Once you have identified what the issue is about and which product/repo it relates to, attempt to investigate the root cause by reading relevant source code from the appropriate **public** ecosystem repository.
-
-### Ecosystem Repository Map
-
-| Product label | Repository to investigate |
-|---|---|
-| `Product: Terraform (AVM)` | `Azure/terraform-azurerm-avm-ptn-alz` |
-| `Product: ALZ Provider (Terraform)` | `Azure/terraform-provider-alz` |
-| `Product: Accelerator :zap:` (Terraform) | `Azure/alz-terraform-accelerator` |
-| `Product: Accelerator :zap:` (Bootstrap) | `Azure/accelerator-bootstrap-modules` |
-| `Product: Accelerator :zap:` (Bicep) | `Azure/alz-bicep-accelerator` |
-| `Product: Bicep (AVM)` | `Azure/alz-bicep-accelerator` |
-| `Product: Bicep (Classic)` | `Azure/ALZ-Bicep` |
-| `Product: Azure Policy :shield:` | `Azure/Enterprise-Scale` and `Azure/Azure-Landing-Zones-Library` |
-| `Product: Library` | `Azure/Azure-Landing-Zones-Library` |
-| `Product: ALZ PowerShell` | `Azure/ALZ-PowerShell-Module` |
-| `Product: Portal` | `Azure/Enterprise-Scale` |
-| `Product: Terraform (Classic)` | `Azure/terraform-azurerm-caf-enterprise-scale` |
-| Hub & spoke networking | `Azure/terraform-azurerm-avm-ptn-alz-connectivity-hub-and-spoke-vnet` |
-| Virtual WAN networking | `Azure/terraform-azurerm-avm-ptn-alz-connectivity-virtual-wan` |
-| Private DNS zones | `Azure/terraform-azurerm-avm-ptn-network-private-link-private-dns-zones` |
-
-### Investigation Guidelines
-
-- Use the GitHub MCP tools to read files, search code, and list commits in the relevant public repo.
-- Use the **Microsoft Docs MCP** (`microsoftdocs`) to query official Azure and Cloud Adoption Framework (CAF) documentation when you need to:
-  - Verify expected Azure service behaviour (e.g., "is this how Azure Policy assignment inheritance is supposed to work?")
-  - Look up ALZ architecture guidance or design recommendations from `learn.microsoft.com`
-  - Determine whether a reported behaviour is a bug vs. expected/by-design per Microsoft documentation
-  - Ground your understanding of a feature request against the official ALZ guidance
-- Look for the specific module, file, variable, or resource referenced in the issue.
-- If you can identify a likely root cause or a specific file/line that may need changing, include that in your triage comment as a suggested fix.
-- **Keep suggestions brief and actionable** — e.g., "The variable `x` in `modules/foo/variables.tf` appears to be missing a default value" or "The policy assignment in `platform/alz/policy_assignments/` may need updating".
-- If the issue is a **question, feature request, or consideration** rather than a bug, that is perfectly fine. Note it as such in your triage comment — e.g., "This appears to be a question about configuration options rather than a bug" or "This is a feature request for consideration by the team".
-- If you **cannot** identify a likely fix (the issue is unclear, too complex, or you lack context), simply state that further investigation is needed. Do not speculate.
-- **Never create PRs, issues, or comments in other repos.** Your output is limited to the triage comment on this issue.
 
 ---
 
 ## Safe Outputs
 
-- If you **close the issue** as a duplicate: Use `close-issue` with state reason `not_planned`, then use `add-comment` for the triage summary.
+**Important:** Do not emit any safe outputs until ALL analysis steps (Steps 1–5) are complete.
+
+- If you **close the issue** as a duplicate: Use `add-comment` for the triage summary **first**, then use `close-issue` with state reason `not_planned`.
 - If you **add labels AND post a comment** (most common case): Call **both** `add-labels` (to apply labels to the issue) AND `add-comment` (for the triage summary). ⚠️ Listing label names inside the comment body does NOT apply them — you MUST call `add-labels` as a separate action.
 - If you **only post a comment** (no labels to add, no close): Use `add-comment`.
-- If the issue **has already been triaged** or there is **nothing to do**: Use `noop` with a clear message.
+- If the issue has already been triaged or there is genuinely nothing to add: Use `add-comment` with the message "Issue assessed, no input from GitHub agentic workflow agent."
 
 ---
 
@@ -277,3 +296,4 @@ Once you have identified what the issue is about and which product/repo it relat
 - The **Microsoft Docs MCP** (`microsoftdocs`) gives you access to official Azure and CAF documentation on `learn.microsoft.com`. Use it to ground your answers in authoritative guidance, especially for architecture/design questions.
 - **Never create issues, PRs, or comments in other repos.** All write operations are limited to this repository.
 - Be conservative with duplicate detection. False positives (wrongly closing a valid issue) are much worse than false negatives (leaving a non-duplicate open).
+- When composing your triage comment, **never reproduce `@mentions`** (e.g., `@username`) from the issue body or linked content. Summarise user references without the `@` prefix to avoid notification spam.

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -23,6 +23,8 @@ network:
 safe-outputs:
   add-comment:
     max: 1
+  add-labels:
+    max: 10
   update-issue:
     max: 1
   close-issue:
@@ -133,7 +135,7 @@ Use the issue content to determine appropriate labels from these categories:
 - **NEVER remove the `Needs: Triage :mag:` label.** This label is used by the human review process and must always remain on the issue. If it is already present, leave it. If it is not present, do NOT add it either — this is managed by the issue template.
 - **NEVER add or remove** `Status:`, `Needs:`, `Transfer From:`, or `Variant:` labels. These are managed by the human triage team.
 - **Only add** `Product:`, `Topic:`, and `Area:` labels based on issue content analysis.
-- Use the `update-issue` safe output to attach labels. When updating, always **preserve all existing labels** and only add new ones.
+- Use the `add-labels` safe output to attach labels. This is the **only** way to actually apply labels to the issue — listing label names in the comment body does NOT apply them.
 
 ---
 
@@ -250,8 +252,8 @@ Once you have identified what the issue is about and which product/repo it relat
 ## Safe Outputs
 
 - If you **close the issue** as a duplicate: Use `close-issue` with state reason `not_planned`, then use `add-comment` for the triage summary.
-- If you **add labels**: Use `update-issue` to attach labels (preserving existing labels).
-- If you **only post a comment** (no labels, no close): Use `add-comment`.
+- If you **add labels AND post a comment** (most common case): Call **both** `add-labels` (to apply labels to the issue) AND `add-comment` (for the triage summary). ⚠️ Listing label names inside the comment body does NOT apply them — you MUST call `add-labels` as a separate action.
+- If you **only post a comment** (no labels to add, no close): Use `add-comment`.
 - If the issue **has already been triaged** or there is **nothing to do**: Use `noop` with a clear message.
 
 ---


### PR DESCRIPTION
## Summary

This PR fixes the issue triage GitHub Agentic Workflow and improves the prompt based on a systematic rubber duck critique.

### Bug Fix (Commit 1)
- **Root cause:** The agent used `update-issue` for labels, but its tool description doesn't mention labels - so labels were listed in the comment but never applied ([workflow run #24306598438](https://github.com/Azure/Azure-Landing-Zones/actions/runs/24306598438))
- **Fix:** Added `add-labels: max: 10` to safe-outputs and updated the prompt to use `add-labels` exclusively

### New Capability (Commits 2-3)
- Added **Microsoft Docs MCP server** (`microsoftdocs`) for grounding triage answers in official Azure/CAF documentation
- Added `learn.microsoft.com` to network allowlist
- Updated prompt with 4 concrete scenarios for when to use the MCP

### Prompt Improvements (Commit 4)
9 changes from rubber duck critique:

| # | Change | Detail |
|---|--------|--------|
| 1 | Step ordering | Comment is now Step 6 (last); analysis steps 1-5 run first |
| 2 | Always comment | Removed `noop`; always posts a comment, even when nothing to add |
| 3 | Duplicate flow | Comment-first-then-close; advises creator to reopen if incorrect |
| 4 | Multiple product labels | Changed from 'ONE primary' to 'all that are relevant' |
| 5 | Label file fallback | Skips labels and notes in comment if `repo-labels.json` missing |
| 6 | Accelerator routing | Per-clue routing to 3 repos (TF/Bootstrap/Bicep) |
| 7 | Docs/meta guidance | Investigate this repo for docs/site/workflow issues |
| 8 | `@mention` defence | Never reproduce `@mentions` from issue text |
| 9 | Default branch | Uses 'default branch' instead of hardcoded 'main' |

### Validated False Positives (no action needed)
- `issues: read` is correct - gh-aw strict mode; writes handled by `safe_outputs` job
- XPIA prompt injection defence - already injected automatically by the framework

### Testing
- All 4 commits compile cleanly: `gh aw compile issue-triage` -> 0 errors, 0 warnings
