### PR TITLE
Update GitHub prerequisites and token instructions

### DIFF
--- a/docs/content/accelerator/1_prerequisites/azuredevops.md
+++ b/docs/content/accelerator/1_prerequisites/azuredevops.md
@@ -23,7 +23,7 @@ This first PAT is referred to as `token-1`.
 1. Ensure you navigate to the organization you want to deploy to.
 1. Click the `User settings` icon in the top right and select `Personal access tokens`.
 1. Click `+ New Token`.
-1. Enter `Azure Landing Zone Terraform Accelerator` in the `Name` field.
+1. Enter `Azure Landing Zone` in the `Name` field.
 1. Alter the `Expiration` drop down and select `Custom defined`.
 1. Choose tomorrows date in the date picker.
 1. Click the `Show all scopes` link at the bottom.

--- a/docs/content/accelerator/1_prerequisites/azuredevops.md
+++ b/docs/content/accelerator/1_prerequisites/azuredevops.md
@@ -41,12 +41,23 @@ This first PAT is referred to as `token-1`.
 1. Copy the token and save it somewhere safe.
 1. Click `Close`.
 
-If you are using self-hosted runners, you will need to create a second PAT that we'll refer to as `token-2` for them. You can do this by following the steps above with the following differences:
+If you are using self-hosted runners, you will need to create a second PAT that we'll refer to as `token-2` for them. You can do this by following these steps:
 
-1. Select the maximum value for the `Expiration` field (this allows up to 1 year). 
+1. Navigate to [dev.azure.com](https://dev.azure.com) and sign in to your organization.
+1. Ensure you navigate to the organization you want to deploy to.
+1. Click the `User settings` icon in the top right and select `Personal access tokens`.
+1. Click `+ New Token`.
+1. Enter `Azure Landing Zone Runners` in the `Name` field.
+1. Alter the `Expiration` drop down and select `Custom defined`.
+1. Select the maximum value for the `Expiration` field (this allows up to 1 year).
 
     {{< hint type=note >}}
 You may want to set a shorter expiration date for security reasons. In either case, you will need to have a process in place to extend the expiration date of the token before it expires.
     {{< /hint >}}
 
-1. Select only the `Agent Pools`: `Read & manage` scope.
+1. Click the `Show all scopes` link at the bottom.
+1. Check the following scope:
+    1. `Agent Pools`: `Read & manage`
+1. Click `Create`.
+1. Copy the token and save it somewhere safe.
+1. Click `Close`.

--- a/docs/content/accelerator/1_prerequisites/github.md
+++ b/docs/content/accelerator/1_prerequisites/github.md
@@ -37,7 +37,7 @@ This first PAT is referred to as `token-1`.
 1. Scroll down and click on `Developer Settings` in the left navigation.
 1. Click `Personal access tokens` in the left navigation and select `Fine-grained tokens`.
 1. Click `Generate new token` at the top.
-1. Enter `Azure Landing Zone Terraform Accelerator` in the `Token name` field.
+1. Enter `Azure Landing Zone` in the `Token name` field.
 1. Alter the `Resource owner` drop down and select your organization.
 1. Alter the `Expiration` drop down and select `Custom`.
 1. Choose tomorrows date in the date picker.
@@ -69,7 +69,7 @@ You may want to set a shorter expiration date for security reasons. In either ca
 1. Scroll down and click on `Developer Settings` in the left navigation.
 1. Click `Personal access tokens` in the left navigation and select `Fine-grained tokens`.
 1. Click `Generate new token` at the top.
-1. Enter `Azure Landing Zone Terraform Accelerator Runner Registration` in the `Token name` field.
+1. Enter `Azure Landing Zone Runners` in the `Token name` field.
 1. Alter the `Resource owner` drop down and select your organization.
 1. Alter the `Expiration` drop down and select `No Expiration`.
     {{< hint type=note >}}


### PR DESCRIPTION
This pull request updates the documentation to simplify and standardize the naming of personal access tokens (PATs) used for Azure DevOps and GitHub integration. The changes focus on making the token names shorter and more consistent across the setup guides.

Documentation updates for PAT naming:

* Updated the recommended PAT name from `Azure Landing Zone Terraform Accelerator` to `Azure Landing Zone` in both the Azure DevOps (`azuredevops.md`) and GitHub (`github.md`) prerequisite guides to ensure consistency and simplicity. [[1]](diffhunk://#diff-a83ba1cf635cee577eff9f83a02e96e777d1b88014b422391683ea4715413b01L26-R26) [[2]](diffhunk://#diff-1af154a0d23b765e4af06630f94e4363e2be4a45f122108cee953d9824dea32cL40-R40)
* Changed the GitHub runner registration PAT name from `Azure Landing Zone Terraform Accelerator Runner Registration` to `Azure Landing Zone Runners` for clarity and brevity.