### PR TITLE
docs: clarify RBAC update when excluding private DNS policy

### DIFF
--- a/docs/content/bicep/howtos/modifyingPolicyAssignments.md
+++ b/docs/content/bicep/howtos/modifyingPolicyAssignments.md
@@ -262,6 +262,17 @@ param landingzonesCorpConfig = {
 }
 ```
 
+You must also update the cross-management group RBAC parameter file. The Platform Connectivity RBAC module references the `Deploy-Private-DNS-Zones` policy assignment as an `existing` resource to retrieve its managed identity. If the policy assignment is excluded but the RBAC module is not updated, the deployment will fail because the referenced policy assignment does not exist.
+This behavior is similar to the `Enable-DDoS-VNET` policy assignment, where associated RBAC modules must also be updated when excluding the policy assignment.
+
+**platform/platform-connectivity/main-rbac.bicepparam:**
+
+```bicep-params
+param parManagementGroupExcludedPolicyAssignments = [
+  'Deploy-Private-DNS-Zones'
+]
+```
+
 When you keep this policy enabled, provide the resource group that hosts your private DNS zones:
 
 ```bicep-params


### PR DESCRIPTION
## Description

Clarifies the Bicep documentation for excluding the `Deploy-Private-DNS-Zones` policy assignment.

When this policy assignment is excluded, the Platform Connectivity RBAC configuration must also exclude the corresponding policy assignment reference. Otherwise, the RBAC module attempts to reference the excluded policy assignment as an existing resource to retrieve its managed identity, which can cause the deployment to fail.

This change documents the required update to `platform/platform-connectivity/main-rbac.bicepparam` using `parManagementGroupExcludedPolicyAssignments`.

This is consistent with the existing handling of the `Enable-DDoS-VNET` policy assignment and its associated RBAC configuration.

## Related issue

Fixes #4200

## Changes

- Documented the required cross-management group RBAC configuration when excluding `Deploy-Private-DNS-Zones`.
- Added an example for `parManagementGroupExcludedPolicyAssignments`.
- Clarified why excluding the policy assignment without updating the RBAC configuration can cause deployment failure.

## Testing

Documentation-only change. Verified the documented configuration and affected Bicep/RBAC relationship.