### PR TITLE
docs(terraform): document cloud-specific policy version differences

### DIFF
--- a/docs/content/terraform/howtos/modifyingPolicyAssets.md
+++ b/docs/content/terraform/howtos/modifyingPolicyAssets.md
@@ -99,14 +99,12 @@ management_groups:
 
 Once you have done this, you can deploy the ALZ module, specifying the `architecture_name` variable to point to your custom architecture definition.
 
-## Cloud-specific policy versions
+## definitionVersion override limitation
 
-{{< hint type=note >}}
-Built-in Azure Policy definitions and initiatives are not always available at the same version across all Azure clouds.
+{{< hint type="warning" >}}
+The policy assignment override flow does not currently support `definitionVersion` overrides.
 
-For example, Azure Government may not have the same built-in policy or initiative versions that are available in Azure Commercial.
+Any `definitionVersion` value provided through `policy_assignments_to_modify` is ignored when policy assignment properties are generated.
 {{< /hint >}}
 
-If your deployment requires a specific policy definition or initiative version that is unavailable in the target cloud, modifying policy assignments alone may not be sufficient.
-
-In these scenarios, use custom policy assets and archetype overrides to manage policy content and versioning explicitly within your custom library.
+For cloud-specific version requirements, create a custom policy assignment asset in your custom library and replace the built-in assignment using an archetype override.

--- a/docs/content/terraform/howtos/modifyingPolicyAssets.md
+++ b/docs/content/terraform/howtos/modifyingPolicyAssets.md
@@ -104,7 +104,7 @@ Once you have done this, you can deploy the ALZ module, specifying the `architec
 {{< hint type="warning" >}}
 The policy assignment override flow does not currently support `definitionVersion` overrides.
 
-Any `definitionVersion` value provided through `policy_assignments_to_modify` is ignored when policy assignment properties are generated.
+If a specific `definitionVersion` is required, create a custom policy assignment asset in your custom library and replace the built-in assignment using an archetype override.
 {{< /hint >}}
 
 For cloud-specific version requirements, create a custom policy assignment asset in your custom library and replace the built-in assignment using an archetype override.

--- a/docs/content/terraform/howtos/modifyingPolicyAssets.md
+++ b/docs/content/terraform/howtos/modifyingPolicyAssets.md
@@ -98,3 +98,15 @@ management_groups:
 ```
 
 Once you have done this, you can deploy the ALZ module, specifying the `architecture_name` variable to point to your custom architecture definition.
+
+## Cloud-specific policy versions
+
+{{< hint type=note >}}
+Built-in Azure Policy definitions and initiatives are not always available at the same version across all Azure clouds.
+
+For example, Azure Government may not have the same built-in policy or initiative versions that are available in Azure Commercial.
+{{< /hint >}}
+
+If your deployment requires a specific policy definition or initiative version that is unavailable in the target cloud, modifying policy assignments alone may not be sufficient.
+
+In these scenarios, use custom policy assets and archetype overrides to manage policy content and versioning explicitly within your custom library.


### PR DESCRIPTION
## Summary

This PR adds documentation describing cloud-specific differences in Azure Policy built-in definition and initiative versions.

## Context

Issue #4213 identified that built-in policy and initiative versions can differ across Azure clouds, including Azure Government. In some scenarios, a specific version available in Azure Commercial may not yet be available in Azure Government.

## Changes

- Added guidance to modifyingPolicyAssets.md
- Documented cloud-specific policy version considerations
- Added recommendation to use custom policy assets and archetype overrides when versioning requirements differ across clouds

## Testing

Documentation-only change.

Fixes [#4213] [https://github.com/Azure/Azure-Landing-Zones/issues/4213]