### PR TITLE
docs: add AMBA Service Health duplicate warning guidance

### DIFF
--- a/docs/content/accelerator/starter-terraform/options/amba.md
+++ b/docs/content/accelerator/starter-terraform/options/amba.md
@@ -44,9 +44,7 @@ management_groups:
 {{< hint type=warning >}}
 When deploying the `amba_root` archetype alongside the ALZ archetype, remove`Deploy-SvcHealth-BuiltIn` from the custom ALZ archetype override used by`root_custom`.
 
-AMBA already provides Service Health alerting through`Deploy-AMBA-Res-SvcHlth`. If both assignments remain enabled, they can create
-duplicate Service Health alert rules and action groups in separate resource
-groups.
+AMBA already provides Service Health alerting through`Deploy-AMBA-Res-SvcHlth`. If both assignments remain enabled, they can create duplicate Service Health alert rules and action groups in separate resource groups.
 {{< /hint >}}
 
 3. Before deployment, there are a couple of pre-requisites that need to be completed, they include creating a managed identity in order to query Resource Graph for alerts and a resource group to store the alert/monitoring assets. Start by locating the `platform-landing-zone.tfvars` >`custom_replacements` > `names` block setting and add the following code:

--- a/docs/content/accelerator/starter-terraform/options/amba.md
+++ b/docs/content/accelerator/starter-terraform/options/amba.md
@@ -41,6 +41,15 @@ management_groups:
     parent_id: null
 {{< / highlight >}}
 
+{{< hint type=warning >}}
+When deploying the `amba_root` archetype alongside the ALZ archetype, remove`Deploy-SvcHealth-BuiltIn` from the custom ALZ archetype override used by`root_custom`.
+
+AMBA already provides Service Health alerting through`Deploy-AMBA-Res-SvcHlth`. If both assignments remain enabled, they can create
+duplicate Service Health alert rules and action groups in separate resource
+groups.
+{{< /hint >}}
+
+
 3. Before deployment, there are a couple of pre-requisites that need to be completed, they include creating a managed identity in order to query Resource Graph for alerts and a resource group to store the alert/monitoring assets. Start by locating the `platform-landing-zone.tfvars` >`custom_replacements` > `names` block setting and add the following code:
 
 {{< highlight terraform "linenos=table" >}}

--- a/docs/content/accelerator/starter-terraform/options/amba.md
+++ b/docs/content/accelerator/starter-terraform/options/amba.md
@@ -42,9 +42,9 @@ management_groups:
 {{< / highlight >}}
 
 {{< hint type=warning >}}
-When deploying the `amba_root` archetype alongside the ALZ archetype, remove`Deploy-SvcHealth-BuiltIn` from the custom ALZ archetype override used by`root_custom`.
+When deploying the `amba_root` archetype alongside the ALZ archetype, remove `Deploy-SvcHealth-BuiltIn` from the custom ALZ archetype override used by `root_custom`.
 
-AMBA already provides Service Health alerting through`Deploy-AMBA-Res-SvcHlth`. If both assignments remain enabled, they can create duplicate Service Health alert rules and action groups in separate resource groups.
+AMBA already provides Service Health alerting through `Deploy-AMBA-Res-SvcHlth`. If both assignments remain enabled, they can create duplicate Service Health alert rules and action groups in separate resource groups.
 {{< /hint >}}
 
 3. Before deployment, there are a couple of pre-requisites that need to be completed, they include creating a managed identity in order to query Resource Graph for alerts and a resource group to store the alert/monitoring assets. Start by locating the `platform-landing-zone.tfvars` >`custom_replacements` > `names` block setting and add the following code:

--- a/docs/content/accelerator/starter-terraform/options/amba.md
+++ b/docs/content/accelerator/starter-terraform/options/amba.md
@@ -49,7 +49,6 @@ duplicate Service Health alert rules and action groups in separate resource
 groups.
 {{< /hint >}}
 
-
 3. Before deployment, there are a couple of pre-requisites that need to be completed, they include creating a managed identity in order to query Resource Graph for alerts and a resource group to store the alert/monitoring assets. Start by locating the `platform-landing-zone.tfvars` >`custom_replacements` > `names` block setting and add the following code:
 
 {{< highlight terraform "linenos=table" >}}


### PR DESCRIPTION
##Overview

Docs update for #4210 

This PR updates the Terraform AMBA option documentation to clarify Service Health behavior when AMBA is enabled alongside ALZ.

##What changed

**Added warning**
When deploying the `amba_root` archetype alongside the ALZ archetype, remove`Deploy-SvcHealth-BuiltIn` from the custom ALZ archetype override used by`root_custom`.

AMBA already provides Service Health alerting through`Deploy-AMBA-Res-SvcHlth`. If both assignments remain enabled, they can create duplicate Service Health alert rules and action groups in separate resource groups.