### PR TITLE
docs: clarify parent management group choice in Decision 6

### DIFF
--- a/docs/content/accelerator/0_planning.md
+++ b/docs/content/accelerator/0_planning.md
@@ -119,9 +119,20 @@ The `starter_locations` setting is in the platform landing zone configuration fi
 
 ### Decision 6 - Choose a parent management group
 
-The parent management group will contain the management groups created by the bootstrap and must already exist.
+The parent management group will contain the management groups created by the bootstrap and must already exist. This can be the `Tenant Root Group` or an existing management group underneath it.
 
-The Platform landing zone hierarchy is built underneath it, with only permission applied at that scope (no policies are applied at that scope).
+The bootstrap creates an intermediate root management group under the parent you choose and builds the Platform landing zone hierarchy underneath that. Role assignments for the identities that run the deployment are applied at the intermediate root management group, and no policies are applied at the parent scope.
+
+Choose either:
+
+* `Tenant Root Group`: The intermediate root management group is created directly underneath it, matching the [Azure landing zone architecture](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone#azure-landing-zone-architecture).
+* An existing management group: The intermediate root management group is created one level deeper, underneath that management group. Choose this if you cannot be granted `Owner` on the `Tenant Root Group`, or if the hierarchy needs to inherit policies or role assignments from an existing management group.
+
+You need `Owner` on the parent management group you choose, as described in the [phase 1 prerequisites]({{< relref "1_prerequisites/platform-subscriptions">}}) and the [Permissions FAQ]({{< relref "faq/permissions">}}).
+
+{{< hint type=note >}}
+Adding a management group above the intermediate root management group is not required in order to use your own naming. The intermediate root management group is not fixed to `Azure Landing Zones`. For Terraform, its ID and display name come from the management group with no parent in your architecture definition. See [Customize Management Group Names and IDs]({{< relref "starter-terraform/options/management-groups">}}).
+{{< /hint >}}
 
 Fill out the `Parent management group id` value with the management group you have chosen.
 


### PR DESCRIPTION
## Overview

Fixes [#4198](https://github.com/Azure/Azure-Landing-Zones/issues/4198)

Decision 6 asks you to choose a parent management group, but does not say that this can be the `Tenant Root Group` or an existing management group underneath it, and gives no criterion for choosing between the two. The issue asks why you would pick either option, and why using an existing management group appears to add a level compared with the published Azure landing zone architecture diagrams.

This also corrects a statement in the same section that has been stale since v7.0.0.

## Changes

`docs/content/accelerator/0_planning.md`, Decision 6 only.

- State both options for the parent management group, and when to choose each.
- Explain that the bootstrap creates an intermediate root management group under the parent you choose, and builds the Platform landing zone hierarchy underneath that.
- Document the `Owner` requirement on the chosen parent, linking to the phase 1 prerequisites and the Permissions FAQ.
- Note that adding a management group above the intermediate root management group is not required in order to use your own naming, linking to the Terraform customization page.

### Correction

The current text says the hierarchy is built underneath the parent "with only permission applied at that scope". This has not been accurate since v7.0.0:

> The role assignments are now just applied at the intermediate root management group, they are no longer applied at the parent management group.

The "no policies are applied at that scope" half is still correct and is retained.

## Testing

Documentation-only change.

- `hugo` builds successfully (358 pages, no errors). All three `{{< relref >}}` links resolve.
- Link text matches the target page titles (`Platform Subscriptions and Permissions`, `Permissions FAQ`, `Customize Management Group Names and IDs`).
- The described behaviour was checked against the bootstrap modules: the intermediate root management group is created under `root_parent_management_group_id`, and for Terraform its ID and display name are taken from the management group with no `parent_id` in the architecture definition. The renaming guidance matches the existing `contoso-alz` / `Contoso` worked example in the Terraform options documentation.
- The naming note is scoped to Terraform because there is no equivalent management group customization page under `starter-bicep`.