### PR TITLE
docs(accelerator): add GitHub runner PAT renewal guidance (#4202)

### DIFF
--- a/docs/content/accelerator/1_prerequisites/github.md
+++ b/docs/content/accelerator/1_prerequisites/github.md
@@ -79,6 +79,6 @@ You can do this post bootstrap deployment to limit access to only the repository
     1. `Self-hosted runners`: `Read and write`  Only required if you plan to use Runner Groups at the organization level.
 1. Click `Generate token`.
 1. Copy the token and save it somewhere safe.
-{{< hint type="note" >}}
-For recovery instructions after a GitHub self-hosted runner PAT expires, see the troubleshooting guide.
+{{< hint type=note >}}
+For recovery instructions after a GitHub self-hosted runner PAT expires, see [GitHub self-hosted runners are offline after the runner PAT expires]({{< relref "../troubleshooting#github-self-hosted-runners-are-offline-after-the-runner-pat-expires" >}}).
 {{< /hint >}}

--- a/docs/content/accelerator/1_prerequisites/github.md
+++ b/docs/content/accelerator/1_prerequisites/github.md
@@ -80,5 +80,5 @@ You can do this post bootstrap deployment to limit access to only the repository
 1. Click `Generate token`.
 1. Copy the token and save it somewhere safe.
 {{< hint type=note >}}
-For recovery instructions after a GitHub self-hosted runner PAT expires, see [GitHub self-hosted runners are offline after the runner PAT expires]({{< relref "../troubleshooting#github-self-hosted-runners-are-offline-after-the-runner-pat-expires" >}}).
+For recovery instructions after a GitHub self-hosted runner PAT expires, see [GitHub self-hosted runners are offline after the runner PAT expires]({{< relref "../troubleshooting#github-self-hosted-runners-are-offline-after-the-pat-expires" >}}).
 {{< /hint >}}

--- a/docs/content/accelerator/1_prerequisites/github.md
+++ b/docs/content/accelerator/1_prerequisites/github.md
@@ -93,10 +93,10 @@ Symptoms of an expired runner PAT include:
 ### Renew the Runner PAT
 
 1. Generate a new GitHub Personal Access Token using the same permissions described in the `token-2` section above.
-2. Update the `github_runners_personal_access_token` value in your accelerator configuration (`inputs.yaml`) with the new PAT.
+2. Update the `github_runners_personal_access_token` value in `inputs.yaml` with the new PAT.
 3. Re-run `Deploy-Accelerator` using the original accelerator deployment configuration.
 
-### Alternative: Targeted Terraform Update
+### Alternative: Targeted Terraform Update and Apply
 
 If you prefer to update only the runner infrastructure:
 

--- a/docs/content/accelerator/1_prerequisites/github.md
+++ b/docs/content/accelerator/1_prerequisites/github.md
@@ -87,7 +87,7 @@ If you use self-hosted GitHub runners, the runner Personal Access Token (`token-
 Symptoms of an expired runner PAT include:
 
 - GitHub runners no longer appear as online.
-- Azure Container Instance logs show `401 Bad credentials` errors.
+- Azure Container Instances (ACI) logs show `401 Bad credentials` errors.
 - Runner registration fails when requesting a new registration token from GitHub.
 
 ### Renew the Runner PAT

--- a/docs/content/accelerator/1_prerequisites/github.md
+++ b/docs/content/accelerator/1_prerequisites/github.md
@@ -80,3 +80,34 @@ You can do this post bootstrap deployment to limit access to only the repository
 1. Click `Generate token`.
 1. Copy the token and save it somewhere safe.
 
+## Renewing an Expired GitHub Runner PAT
+
+If you use self-hosted GitHub runners, the runner Personal Access Token (`token-2`) may expire depending on the expiration period selected when it was created.
+
+Symptoms of an expired runner PAT include:
+
+- GitHub runners no longer appear as online.
+- Azure Container Instance logs show `401 Bad credentials` errors.
+- Runner registration fails when requesting a new registration token from GitHub.
+
+### Renew the Runner PAT
+
+1. Generate a new GitHub Personal Access Token using the same permissions described in the `token-2` section above.
+2. Update the `github_runners_personal_access_token` value in your accelerator configuration (`inputs.yaml`) with the new PAT.
+3. Re-run `Deploy-Accelerator` using the original accelerator deployment configuration.
+
+### Alternative: Targeted Terraform Update
+
+If you prefer to update only the runner infrastructure:
+
+1. Update the PAT value used by the bootstrap deployment.
+2. Run a targeted Terraform plan and apply against the Azure Container Instance runner resources.
+3. Verify the runners successfully register with GitHub.
+
+### Validation
+
+After updating the PAT:
+
+- Verify runners appear under GitHub Organization → Settings → Actions → Runners.
+- Verify Azure Container Instance logs show successful runner registration.
+- Confirm runner jobs can be picked up successfully.

--- a/docs/content/accelerator/1_prerequisites/github.md
+++ b/docs/content/accelerator/1_prerequisites/github.md
@@ -79,35 +79,6 @@ You can do this post bootstrap deployment to limit access to only the repository
     1. `Self-hosted runners`: `Read and write`  Only required if you plan to use Runner Groups at the organization level.
 1. Click `Generate token`.
 1. Copy the token and save it somewhere safe.
-
-## Renewing an Expired GitHub Runner PAT
-
-If you use self-hosted GitHub runners, the runner Personal Access Token (`token-2`) may expire depending on the expiration period selected when it was created.
-
-Symptoms of an expired runner PAT include:
-
-- GitHub runners no longer appear as online.
-- Azure Container Instances (ACI) logs show `401 Bad credentials` errors.
-- Runner registration fails when requesting a new registration token from GitHub.
-
-### Renew the Runner PAT
-
-1. Generate a new GitHub Personal Access Token using the same permissions described in the `token-2` section above.
-2. Update the `github_runners_personal_access_token` value in `inputs.yaml` with the new PAT.
-3. Re-run `Deploy-Accelerator` using the original accelerator deployment configuration.
-
-### Alternative: Targeted Terraform Update and Apply
-
-If you prefer to update only the runner infrastructure:
-
-1. Update the PAT value used by the bootstrap deployment.
-2. Run a targeted Terraform plan and apply against the Azure Container Instance runner resources.
-3. Verify the runners successfully register with GitHub.
-
-### Validation
-
-After updating the PAT:
-
-- Verify runners appear under GitHub Organization → Settings → Actions → Runners.
-- Verify Azure Container Instance logs show successful runner registration.
-- Confirm runner jobs can be picked up successfully.
+{{< hint type="note" >}}
+For recovery instructions after a GitHub self-hosted runner PAT expires, see the troubleshooting guide.
+{{< /hint >}}

--- a/docs/content/accelerator/troubleshooting.md
+++ b/docs/content/accelerator/troubleshooting.md
@@ -107,12 +107,13 @@ You have two options to resolve this:
 │
 ╵
 ```
+
 ### GitHub self-hosted runners are offline after the PAT expires
 
-If the GitHub self-hosted runner PAT (token-2) expires, the Azure Container Instances (ACI) may fail to register with GitHub. Common errors include:
+If the GitHub self-hosted runner PAT (`token-2`) expires, the Azure Container Instances (ACI) may fail to register with GitHub. Common errors include:
 
-- 401 Bad credentials
-- An error occurred: Not configured
+- `401 Bad credentials`
+- `An error occurred: Not configured`
 
 #### Recovery
 
@@ -120,27 +121,37 @@ This procedure applies to existing Terraform and Bicep Platform landing zone dep
 
 This procedure updates only the GitHub bootstrap runner ACIs; it does not redeploy the Platform landing zone.
 
-- Create a new GitHub runner PAT with the permissions described in the token-2 section.
-- From the PowerShell session used to run Terraform, set the new PAT:
-  $env:TF_VAR_github_runners_personal_access_token = "<new-pat>"
+1. Create a new GitHub runner PAT with the permissions described in the `token-2` section in the GitHub prerequisites documentation.
 
-- Use the original Accelerator output directory and Terraform state. Do not create a new deployment or use the `-Destroy` parameter.
+1. From the PowerShell session used to run Terraform, set the new PAT:
 
-- Change to the existing GitHub bootstrap Terraform directory and identify the runner resources:
+    ```powershell
+    $env:TF_VAR_github_runners_personal_access_token = "<new-pat>"
+    ```
 
-  terraform state list
+1. Use the original Accelerator output directory and Terraform state. Do not create a new deployment or use the `-Destroy` parameter.
 
-- Run a targeted plan and review it before applying:
+1. Change to the existing GitHub bootstrap Terraform directory and identify the runner resources:
 
-  terraform plan `
-    -target='module.azure.azurerm_container_group.alz["agent_01"]' `
-    -target='module.azure.azurerm_container_group.alz["agent_02"]'
+    ```powershell
+    terraform state list
+    ```
 
-- Apply the reviewed change using the resource addresses returned by `terraform state list`:
+1. Run a targeted plan and review it before applying:
 
-  terraform apply `
-    -target='module.azure.azurerm_container_group.alz["agent_01"]' `
-    -target='module.azure.azurerm_container_group.alz["agent_02"]'
+    ```powershell
+    terraform plan `
+      -target='module.azure.azurerm_container_group.alz["agent_01"]' `
+      -target='module.azure.azurerm_container_group.alz["agent_02"]'
+    ```
+
+1. Apply the reviewed change using the resource addresses returned by `terraform state list`:
+
+    ```powershell
+    terraform apply `
+      -target='module.azure.azurerm_container_group.alz["agent_01"]' `
+      -target='module.azure.azurerm_container_group.alz["agent_02"]'
+    ```
 
 Changing the secure PAT may replace the runner ACIs. This is expected.
 

--- a/docs/content/accelerator/troubleshooting.md
+++ b/docs/content/accelerator/troubleshooting.md
@@ -107,3 +107,43 @@ You have two options to resolve this:
 │
 ╵
 ```
+### GitHub self-hosted runners are offline after the PAT expires
+
+If the GitHub self-hosted runner PAT (token-2) expires, the Azure Container Instances (ACI) may fail to register with GitHub. Common errors include:
+
+- 401 Bad credentials
+- An error occurred: Not configured
+
+#### Recovery
+
+This procedure applies to existing Terraform and Bicep Platform landing zone deployments. The GitHub bootstrap resources are managed by Terraform in both cases.
+
+This procedure updates only the GitHub bootstrap runner ACIs; it does not redeploy the Platform landing zone.
+
+- Create a new GitHub runner PAT with the permissions described in the token-2 section.
+- From the PowerShell session used to run Terraform, set the new PAT:
+  $env:TF_VAR_github_runners_personal_access_token = "<new-pat>"
+
+- Use the original Accelerator output directory and Terraform state. Do not create a new deployment or use the `-Destroy` parameter.
+
+- Change to the existing GitHub bootstrap Terraform directory and identify the runner resources:
+
+  terraform state list
+
+- Run a targeted plan and review it before applying:
+
+  terraform plan `
+    -target='module.azure.azurerm_container_group.alz["agent_01"]' `
+    -target='module.azure.azurerm_container_group.alz["agent_02"]'
+
+- Apply the reviewed change using the resource addresses returned by `terraform state list`:
+
+  terraform apply `
+    -target='module.azure.azurerm_container_group.alz["agent_01"]' `
+    -target='module.azure.azurerm_container_group.alz["agent_02"]'
+
+Changing the secure PAT may replace the runner ACIs. This is expected.
+
+Do not apply the plan if it includes unexpected changes to GitHub repositories, repository files, management groups, policies, networking, or other customized resources.
+
+After the new runners are online and working, revoke the old PAT.

--- a/docs/content/accelerator/troubleshooting.md
+++ b/docs/content/accelerator/troubleshooting.md
@@ -108,14 +108,14 @@ You have two options to resolve this:
 ╵
 ```
 
-### GitHub self-hosted runners are offline after the PAT expires
+## GitHub self-hosted runners are offline after the PAT expires
 
 If the GitHub self-hosted runner PAT (`token-2`) expires, the Azure Container Instances (ACI) may fail to register with GitHub. Common errors include:
 
 - `401 Bad credentials`
 - `An error occurred: Not configured`
 
-#### Recovery
+### Recovery
 
 This procedure applies to existing Terraform and Bicep Platform landing zone deployments. The GitHub bootstrap resources are managed by Terraform in both cases.
 


### PR DESCRIPTION
## Summary

Adds documentation describing how to renew an expired GitHub Runner Personal Access Token \(PAT\) for self\-hosted runners deployed through the Azure Landing Zone Accelerator.

## Changes

- Added a new **Renewing an Expired GitHub Runner PAT** section to the GitHub prerequisites documentation.
- Documented common symptoms of an expired runner PAT.
- Added guidance for renewing the PAT and updating accelerator configuration.
- Included both the Deploy\-Accelerator approach and targeted Terraform update approach.
- Added validation steps to confirm successful runner registration.

## Related Issue

Fixes #4202 [https://github.com/Azure/Azure-Landing-Zones/issues/4202]

