### PR TITLE
docs(accelerator): add GitHub runner PAT recovery guidance (#4202)

### DIFF
--- a/docs/content/accelerator/1_prerequisites/github.md
+++ b/docs/content/accelerator/1_prerequisites/github.md
@@ -80,3 +80,6 @@ You can do this post bootstrap deployment to limit access to only the repository
 1. Click `Generate token`.
 1. Copy the token and save it somewhere safe.
 
+{{< hint type=note >}}
+If your GitHub self-hosted runner PAT (`token-2`) expires and your runners go offline, see {{< relref "../troubleshooting#github-self-hosted-runners-are-offline-after-the-pat-expires" >}} for recovery steps.
+{{< /hint >}}

--- a/docs/content/accelerator/troubleshooting.md
+++ b/docs/content/accelerator/troubleshooting.md
@@ -150,7 +150,7 @@ This procedure updates only the GitHub bootstrap runner ACIs; it does not redepl
       -target='module.azure.azurerm_container_group.alz["agent_02"]'
     ```
 
-Changing the secure PAT may replace the runner ACIs. This is expected.
+Updating the PAT value may replace the runner ACIs. This is expected.
 
 Do not apply the plan if it includes unexpected changes to GitHub repositories, repository files, management groups, policies, networking, or other customized resources.
 

--- a/docs/content/accelerator/troubleshooting.md
+++ b/docs/content/accelerator/troubleshooting.md
@@ -107,7 +107,7 @@ You have two options to resolve this:
 │
 ╵
 ```
-### GitHub self-hosted runners are offline after the PAT expires
+## GitHub self-hosted runners are offline after the PAT expires
 
 If the GitHub self-hosted runner PAT (`token-2`) expires, the Azure Container Instances (ACI) may fail to register with GitHub. Common errors include:
 

--- a/docs/content/accelerator/troubleshooting.md
+++ b/docs/content/accelerator/troubleshooting.md
@@ -107,3 +107,51 @@ You have two options to resolve this:
 │
 ╵
 ```
+### GitHub self-hosted runners are offline after the PAT expires
+
+If the GitHub self-hosted runner PAT (`token-2`) expires, the Azure Container Instances (ACI) may fail to register with GitHub. Common errors include:
+
+- `401 Bad credentials`
+- `An error occurred: Not configured`
+
+#### Recovery
+
+This procedure applies to existing Terraform and Bicep Platform landing zone deployments. The GitHub bootstrap resources are managed by Terraform in both cases.
+
+This procedure updates only the GitHub bootstrap runner ACIs; it does not redeploy the Platform landing zone.
+
+1. Create a new GitHub runner PAT with the permissions described in the `token-2` section in the GitHub prerequisites documentation.
+1. From the PowerShell session used to run Terraform, set the new PAT:
+
+    ```powershell
+    $env:TF_VAR_github_runners_personal_access_token = "<new-pat>"
+    ```
+
+1. Use the original Accelerator output directory and Terraform state. Do not create a new deployment or use the `-Destroy` parameter.
+1. Change to the existing GitHub bootstrap Terraform directory and identify the runner resources:
+
+    ```powershell
+    terraform state list
+    ```
+
+1. Run a targeted plan and review it before applying:
+
+    ```powershell
+    terraform plan `
+      -target='module.azure.azurerm_container_group.alz["agent_01"]' `
+      -target='module.azure.azurerm_container_group.alz["agent_02"]'
+    ```
+
+1. Apply the reviewed change using the resource addresses returned by `terraform state list`:
+
+    ```powershell
+    terraform apply `
+      -target='module.azure.azurerm_container_group.alz["agent_01"]' `
+      -target='module.azure.azurerm_container_group.alz["agent_02"]'
+    ```
+
+Changing the secure PAT may replace the runner ACIs. This is expected.
+
+Do not apply the plan if it includes unexpected changes to GitHub repositories, repository files, management groups, policies, networking, or other customized resources.
+
+After the new runners are online and working, revoke the old PAT.


### PR DESCRIPTION
## Summary

Adds troubleshooting guidance for recovering GitHub self-hosted runners when the runner PAT (`token-2`) expires.

## Changes

- Added a troubleshooting section for expired GitHub self-hosted runner PATs.
- Documented common symptoms and errors.
- Added recovery steps for updating the PAT and redeploying runner ACIs.
- Added validation guidance to review Terraform plans before applying changes.

## Validation

- Reviewed recovery workflow for existing Terraform and Bicep Platform landing zone deployments.
- Verified formatting and markdown rendering.

## Related Issue

Fixes #4202 [https://github.com/Azure/Azure-Landing-Zones/issues/4202]