### PR TITLE
Fix issue-triage fallback model for agentic workflows

### DIFF
--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -118,7 +118,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
+          GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'gpt-5-mini' }}
           GH_AW_INFO_VERSION: "1.0.65"
           GH_AW_INFO_AGENT_VERSION: "1.0.65"
           GH_AW_INFO_CLI_VERSION: "v0.81.6"
@@ -959,7 +959,7 @@ jobs:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ github.token }}
-          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
+          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'gpt-5-mini' }}
           GH_AW_LLM_PROVIDER: github
           GH_AW_MAX_AI_CREDITS: ${{ vars.GH_AW_DEFAULT_MAX_AI_CREDITS || '1000' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}
@@ -1578,7 +1578,7 @@ jobs:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ github.token }}
-          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
+          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'gpt-5-mini' }}
           GH_AW_LLM_PROVIDER: github
           GH_AW_MAX_AI_CREDITS: ${{ vars.GH_AW_DEFAULT_DETECTION_MAX_AI_CREDITS || '400' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}


### PR DESCRIPTION
## Summary

Fixes Issue \#4255 by updating the Issue Triage workflow fallback model used when repository model variables are not configured.

## Root Cause Analysis

Investigation traced the issue back to PR \#4168 (commit 5dc43b5), which upgraded the GitHub Agentic Workflows assets.

The workflow falls back to claude\-sonnet\-4.6 when the following variables are not configured:

- GH\_AW\_MODEL\_AGENT\_COPILOT
- GH\_AW\_MODEL\_DETECTION\_COPILOT
- GH\_AW\_DEFAULT\_MODEL\_COPILOT

Recent workflow runs failed before issue\-triage logic executed because Agentic Workflows no longer accepts the claude\-sonnet\-4.6 fallback model, resulting in a model validation error.

## Fix

Updated all fallback model references from:

claude\-sonnet\-4.6

to:

gpt\-5\-mini

Locations updated:

- GH\_AW\_INFO\_MODEL
- COPILOT\_MODEL (agent workflow path)
- COPILOT\_MODEL (detection workflow path)

## Validation

- Confirmed workflow fallback references existed in three locations.
- Confirmed no remaining claude\-sonnet\-4.6 fallback references after the change.
- git diff \-\-check passed.
- Change is limited to three fallback model substitutions in a single workflow file.

