### PR TITLE
docs: clarify bootstrap networking resource creation

### DIFF
--- a/docs/content/accelerator/0_planning.md
+++ b/docs/content/accelerator/0_planning.md
@@ -198,6 +198,12 @@ We offer 3 agent / runner and networking options for the bootstrap. The options 
 
 {{< hint type=note >}}
 Self-hosted agents / runners are required for private networking, so that setting will be ignored if private networking is selected.
+
+When using self-hosted agents or runners, the bootstrap deployment may create Azure networking resources to support those services.
+
+Review the networking configuration and address spaces before deployment to ensure they do not overlap with existing corporate or Azure network ranges.
+
+Additional networking settings are available through the bootstrap module configuration and can be customized to meet your organization's networking requirements.
 {{< /hint >}}
 
 Fill out the `Use private networking`, `Use self-hosted agents`, and / or `Use self-hosted runners` values with the settings you have chosen.

--- a/docs/content/accelerator/0_planning.md
+++ b/docs/content/accelerator/0_planning.md
@@ -199,11 +199,11 @@ We offer 3 agent / runner and networking options for the bootstrap. The options 
 {{< hint type=note >}}
 Self-hosted agents / runners are required for private networking, so that setting will be ignored if private networking is selected.
 
-When using self-hosted agents or runners, the bootstrap deployment may create Azure networking resources to support those services.
+When private networking and self-hosted agents or runners are enabled, the bootstrap deployment creates Azure networking resources to support those services.
 
 Review the networking configuration and address spaces before deployment to ensure they do not overlap with existing corporate or Azure network ranges.
 
-Additional networking settings are available through the bootstrap module configuration and can be customized to meet your organization's networking requirements.
+The networking address spaces can be customized through the bootstrap module configuration, including `virtual_network_address_space`, `virtual_network_subnet_address_prefix_container_instances`, and `virtual_network_subnet_address_prefix_private_endpoints`.
 {{< /hint >}}
 
 Fill out the `Use private networking`, `Use self-hosted agents`, and / or `Use self-hosted runners` values with the settings you have chosen.

--- a/docs/content/accelerator/0_planning.md
+++ b/docs/content/accelerator/0_planning.md
@@ -203,7 +203,13 @@ When private networking and self-hosted agents or runners are enabled, the boots
 
 Review the networking configuration and address spaces before deployment to ensure they do not overlap with existing corporate or Azure network ranges.
 
-The networking address spaces can be customized through the bootstrap module configuration, including `virtual_network_address_space`, `virtual_network_subnet_address_prefix_container_instances`, and `virtual_network_subnet_address_prefix_private_endpoints`.
+Networking address spaces can be customized through bootstrap module configuration, including:
+
+- virtual_network_address_space (default: 10.0.0.0/24)
+- virtual_network_subnet_address_prefix_container_instances (default: 10.0.0.0/26)
+- virtual_network_subnet_address_prefix_private_endpoints (default: 10.0.0.64/26)
+
+Review and update these values as needed to align with your organization's IP addressing plan.
 {{< /hint >}}
 
 Fill out the `Use private networking`, `Use self-hosted agents`, and / or `Use self-hosted runners` values with the settings you have chosen.

--- a/docs/content/accelerator/2_bootstrap/_index.md
+++ b/docs/content/accelerator/2_bootstrap/_index.md
@@ -45,6 +45,11 @@ The interactive mode wizard only completes the bootstrap configuration file (`in
     1. Review the bootstrap configuration settings and ensure they are correct.
     {{< hint type=note >}}
     If you are using private networking with self-hosted agents or runners, review the bootstrap networking settings before deployment. Bootstrap deployments that use private networking with self-hosted agents or runners create Azure networking resources, including a Virtual Network, Container Instances subnet, Private Endpoints subnet, NAT Gateway, and Public IP address. Review and configure the networking address space settings to ensure they do not overlap with existing corporate or Azure network ranges. Validate the configured address spaces against your existing network design to avoid address range conflicts.
+    Default networking values are:
+
+    - virtual_network_address_space: 10.0.0.0/24
+    - virtual_network_subnet_address_prefix_container_instances: 10.0.0.0/26
+    - virtual_network_subnet_address_prefix_private_endpoints: 10.0.0.64/26
     {{< /hint >}}
     1. Save any changes to the configuration file.
     1. Open the relevant section below for the platform landing zone configuration file:

--- a/docs/content/accelerator/2_bootstrap/_index.md
+++ b/docs/content/accelerator/2_bootstrap/_index.md
@@ -44,7 +44,7 @@ The interactive mode wizard only completes the bootstrap configuration file (`in
     1. Open your bootstrap configuration file in VS Code. The file is located at `./config/inputs.yaml` in your target directory.
     1. Review the bootstrap configuration settings and ensure they are correct.
     {{< hint type=note >}}
-    If you are using self-hosted agents or runners, review the bootstrap networking settings before deployment. Bootstrap deployments that use self-hosted agents or runners may create Azure networking resources to support those services, and the configured address spaces should be validated against your existing network design to avoid address range conflicts.
+    If you are using private networking with self-hosted agents or runners, review the bootstrap networking settings before deployment. Bootstrap deployments that use private networking with self-hosted agents or runners create Azure networking resources, including a Virtual Network, Container Instances subnet, Private Endpoints subnet, NAT Gateway, and Public IP address. Review and configure the networking address space settings to ensure they do not overlap with existing corporate or Azure network ranges. Validate the configured address spaces against your existing network design to avoid address range conflicts.
     {{< /hint >}}
     1. Save any changes to the configuration file.
     1. Open the relevant section below for the platform landing zone configuration file:

--- a/docs/content/accelerator/2_bootstrap/_index.md
+++ b/docs/content/accelerator/2_bootstrap/_index.md
@@ -43,6 +43,9 @@ The interactive mode wizard only completes the bootstrap configuration file (`in
 
     1. Open your bootstrap configuration file in VS Code. The file is located at `./config/inputs.yaml` in your target directory.
     1. Review the bootstrap configuration settings and ensure they are correct.
+    {{< hint type=note >}}
+    If you are using self-hosted agents or runners, review the bootstrap networking settings before deployment. Bootstrap deployments that use self-hosted agents or runners may create Azure networking resources to support those services, and the configured address spaces should be validated against your existing network design to avoid address range conflicts.
+    {{< /hint >}}
     1. Save any changes to the configuration file.
     1. Open the relevant section below for the platform landing zone configuration file:
 


### PR DESCRIPTION
Fixes #4153

## Summary

Clarifies ALZ Accelerator bootstrap documentation for scenarios where bootstrap networking resources are created.

## Changes

- Added networking guidance to Phase 0 (Planning) and Phase 2 (Bootstrap).
- Clarified that networking resources are created when:
  - Private networking is enabled, and
  - Self-hosted agents/runners are enabled.
- Documented bootstrap networking resources including:
  - Virtual Network
  - Public IP
  - NAT Gateway
  - Container Instances subnet
  - Private Endpoints subnet
- Added guidance to review networking address spaces before deployment.
- Documented configurable networking settings:
  - `virtual_network_address_space`
  - `virtual_network_subnet_address_prefix_container_instances`
  - `virtual_network_subnet_address_prefix_private_endpoints`

## Background

Issue #4153 reported that bootstrap networking resource creation and related networking configuration options were difficult to discover from the primary bootstrap documentation.

Investigation of the accelerator-bootstrap-modules repository confirmed that networking resources are created when private networking and self-hosted agents/runners are enabled together. The documentation now explains when these resources are created and highlights the networking settings that can be customized before deployment to avoid address-space conflicts.